### PR TITLE
[MBUILDCACHE-24] - Fixes IllegalArgumentException in forked executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,24 @@ under the License.
             <version>1.7.35</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.22.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockitoVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junitVersion}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/apache/maven/buildcache/ChainedListener.java
+++ b/src/main/java/org/apache/maven/buildcache/ChainedListener.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.maven.execution.AbstractExecutionListener;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionListener;
+
+class ChainedListener extends AbstractExecutionListener
+{
+
+    private final ExecutionListener delegate;
+
+    private final CopyOnWriteArrayList<ExecutionListener> chainedListeners = new CopyOnWriteArrayList<>();
+
+    ChainedListener( ExecutionListener delegate )
+    {
+        this.delegate = delegate;
+    }
+
+    public boolean chainListener( ExecutionListener listener )
+    {
+        return chainedListeners.addIfAbsent( listener );
+    }
+
+    @Override
+    public void projectDiscoveryStarted( ExecutionEvent event )
+    {
+        delegate.projectDiscoveryStarted( event );
+        chainedListeners.forEach( listener -> listener.projectDiscoveryStarted( event ) );
+    }
+
+    @Override
+    public void sessionStarted( ExecutionEvent event )
+    {
+        delegate.sessionStarted( event );
+        chainedListeners.forEach( listener -> listener.sessionStarted( event ) );
+    }
+
+    @Override
+    public void sessionEnded( ExecutionEvent event )
+    {
+        delegate.sessionEnded( event );
+        chainedListeners.forEach( listener -> listener.sessionEnded( event ) );
+    }
+
+    @Override
+    public void projectSkipped( ExecutionEvent event )
+    {
+        delegate.projectSkipped( event );
+        chainedListeners.forEach( listener -> listener.projectSkipped( event ) );
+    }
+
+    @Override
+    public void projectStarted( ExecutionEvent event )
+    {
+        delegate.projectStarted( event );
+        chainedListeners.forEach( listener -> listener.projectStarted( event ) );
+    }
+
+    @Override
+    public void projectSucceeded( ExecutionEvent event )
+    {
+        delegate.projectSucceeded( event );
+        chainedListeners.forEach( listener -> listener.projectSucceeded( event ) );
+    }
+
+    @Override
+    public void projectFailed( ExecutionEvent event )
+    {
+        delegate.projectFailed( event );
+        chainedListeners.forEach( listener -> listener.projectFailed( event ) );
+    }
+
+    @Override
+    public void forkStarted( ExecutionEvent event )
+    {
+        delegate.forkStarted( event );
+        chainedListeners.forEach( listener -> listener.forkStarted( event ) );
+    }
+
+    @Override
+    public void forkSucceeded( ExecutionEvent event )
+    {
+        delegate.forkSucceeded( event );
+        chainedListeners.forEach( listener -> listener.forkSucceeded( event ) );
+    }
+
+    @Override
+    public void forkFailed( ExecutionEvent event )
+    {
+        delegate.forkFailed( event );
+        chainedListeners.forEach( listener -> listener.forkFailed( event ) );
+    }
+
+    @Override
+    public void mojoSkipped( ExecutionEvent event )
+    {
+        delegate.mojoSkipped( event );
+        chainedListeners.forEach( listener -> listener.mojoSkipped( event ) );
+    }
+
+    @Override
+    public void mojoStarted( ExecutionEvent event )
+    {
+        delegate.mojoStarted( event );
+        chainedListeners.forEach( listener -> listener.mojoStarted( event ) );
+    }
+
+    @Override
+    public void mojoSucceeded( ExecutionEvent event )
+    {
+        delegate.mojoSucceeded( event );
+        chainedListeners.forEach( listener -> listener.mojoSucceeded( event ) );
+    }
+
+    @Override
+    public void mojoFailed( ExecutionEvent event )
+    {
+        delegate.mojoFailed( event );
+        chainedListeners.forEach( listener -> listener.mojoFailed( event ) );
+    }
+
+    @Override
+    public void forkedProjectStarted( ExecutionEvent event )
+    {
+        delegate.forkedProjectStarted( event );
+        chainedListeners.forEach( listener -> listener.forkedProjectStarted( event ) );
+    }
+
+    @Override
+    public void forkedProjectSucceeded( ExecutionEvent event )
+    {
+        delegate.forkedProjectSucceeded( event );
+        chainedListeners.forEach( listener -> listener.forkedProjectSucceeded( event ) );
+    }
+
+    @Override
+    public void forkedProjectFailed( ExecutionEvent event )
+    {
+        delegate.forkedProjectFailed( event );
+        chainedListeners.forEach( listener -> listener.forkedProjectFailed( event ) );
+    }
+
+}

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
@@ -605,7 +605,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
     public String getLocalRepositoryLocation()
     {
         checkInitializedState();
-        return System.getProperty( CACHE_LOCATION_PROPERTY_NAME, getLocal().getLocation() );
+        return getProperty( CACHE_LOCATION_PROPERTY_NAME, getLocal().getLocation() );
     }
 
     @Override

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
@@ -79,6 +79,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
 
     public static final String CONFIG_PATH_PROPERTY_NAME = "maven.build.cache.configPath";
     public static final String CACHE_ENABLED_PROPERTY_NAME = "maven.build.cache.enabled";
+    public static final String CACHE_LOCATION_PROPERTY_NAME = "maven.build.cache.location";
     public static final String SAVE_TO_REMOTE_PROPERTY_NAME = "maven.build.cache.remote.save.enabled";
     public static final String SAVE_NON_OVERRIDEABLE_NAME = "maven.build.cache.remote.save.final";
     public static final String FAIL_FAST_PROPERTY_NAME = "maven.build.cache.failFast";
@@ -604,7 +605,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
     public String getLocalRepositoryLocation()
     {
         checkInitializedState();
-        return getLocal().getLocation();
+        return System.getProperty( CACHE_LOCATION_PROPERTY_NAME, getLocal().getLocation() );
     }
 
     @Override

--- a/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
@@ -29,6 +29,8 @@ import org.apache.maven.buildcache.xml.build.DigestItem;
 import org.apache.maven.buildcache.xml.build.PropertyValue;
 import org.apache.maven.buildcache.xml.config.TrackedProperty;
 import org.apache.maven.model.Dependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.maven.buildcache.checksum.KeyUtils.getArtifactKey;
 
@@ -37,6 +39,8 @@ import static org.apache.maven.buildcache.checksum.KeyUtils.getArtifactKey;
  */
 public class DtoUtils
 {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( DtoUtils.class );
 
     public static String findPropertyValue( String propertyName, CompletedExecution completedExecution )
     {
@@ -130,6 +134,13 @@ public class DtoUtils
         execution.addProperty( valueType );
     }
 
+    /**
+     * Checks that all tracked (for reconciliation purposes) properties present in cached build record
+     *
+     * @param  cachedExecution   mojo execution record (from cache)
+     * @param  trackedProperties list of tracked properties (from config)
+     * @return                   true if all tracked properties are listed in the cache record
+     */
     public static boolean containsAllProperties(
             @Nonnull CompletedExecution cachedExecution, List<TrackedProperty> trackedProperties )
     {
@@ -148,6 +159,8 @@ public class DtoUtils
         {
             if ( !contains( executionProperties, trackedProperty.getPropertyName() ) )
             {
+                LOGGER.warn( "Tracked property `{}` not found in cached build. Execution: {}",
+                        trackedProperty.getPropertyName(), cachedExecution.getExecutionKey() );
                 return false;
             }
         }

--- a/src/test/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategyTest.java
+++ b/src/test/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategyTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.maven.buildcache;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.maven.buildcache.xml.CacheConfig;
+import org.apache.maven.buildcache.xml.build.CompletedExecution;
+import org.apache.maven.buildcache.xml.build.PropertyValue;
+import org.apache.maven.buildcache.xml.config.TrackedProperty;
+import org.apache.maven.plugin.MavenPluginManager;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BuildCacheMojosExecutionStrategyTest
+{
+
+    @Nested
+    class ParametersMatchingTest
+    {
+
+        private BuildCacheMojosExecutionStrategy strategy;
+        private MavenProject projectMock;
+        private MojoExecution executionMock;
+        private CompletedExecution cacheRecordMock;
+        private CacheConfig cacheConfigMock;
+
+        @BeforeEach
+        void setUp()
+        {
+            cacheConfigMock = mock( CacheConfig.class );
+            strategy = new BuildCacheMojosExecutionStrategy(
+                    mock( CacheController.class ),
+                    cacheConfigMock,
+                    mock( MojoParametersListener.class ),
+                    mock( LifecyclePhasesHelper.class ),
+                    mock( MavenPluginManager.class ) );
+
+            projectMock = mock( MavenProject.class );
+            executionMock = mock( MojoExecution.class );
+            cacheRecordMock = mock( CompletedExecution.class );
+        }
+
+        @Test
+        void testBasicParamsMatching()
+        {
+
+            List<Pair<TrackedProperty, PropertyValue>> cacheProperties = Lists.newArrayList(
+                    setupProperty( "bool", "true" ),
+                    setupProperty( "primitive", "1" ),
+                    setupProperty( "file", "c" ),
+                    setupProperty( "path", "../d/e" ),
+                    setupProperty( "list", "[a, b, c]" ),
+                    setupProperty( "array", "{c,d,e}" ),
+                    setupProperty( "nullObject", null ) );
+
+            List<TrackedProperty> trackedProperties = cacheProperties.stream().map( Pair::getLeft )
+                    .collect( Collectors.toList() );
+
+            List<PropertyValue> cacheRecordProperties = cacheProperties.stream().map( Pair::getRight )
+                    .collect( Collectors.toList() );
+
+            when( cacheConfigMock.getTrackedProperties( executionMock ) ).thenReturn( trackedProperties );
+            when( cacheRecordMock.getProperties() ).thenReturn( cacheRecordProperties );
+
+            when( projectMock.getBasedir() ).thenReturn( new File( "/a/b" ) );
+
+            TestMojo testMojo = TestMojo.create(
+                    true,
+                    1,
+                    new File( "/a/b/c" ),
+                    Paths.get( "../d/e" ),
+                    Lists.newArrayList( "a", "b", "c" ),
+                    new String[]
+                    { "c", "d", "e"
+                    } );
+
+            assertTrue( strategy.isParamsMatched( projectMock, executionMock, testMojo, cacheRecordMock ) );
+        }
+
+        @Test
+        void testSkipValue()
+        {
+
+            String propertyName = "anyObject";
+
+            TrackedProperty config = new TrackedProperty();
+            config.setPropertyName( propertyName );
+            config.setSkipValue( "true" );
+
+            // cache is better - not skipped
+            PropertyValue cache = new PropertyValue();
+            cache.setName( propertyName );
+            cache.setValue( "false" );
+
+            when( cacheConfigMock.getTrackedProperties( executionMock ) ).thenReturn( Lists.newArrayList( config ) );
+            when( cacheRecordMock.getProperties() ).thenReturn( Lists.newArrayList( cache ) );
+
+            when( projectMock.getBasedir() ).thenReturn( new File( "." ) );
+
+            // emulating that current build is "skipping" something and literal value is different from the cache
+            TestMojo testMojo = new TestMojo();
+            testMojo.setAnyObject( "true" );
+
+            assertTrue( strategy.isParamsMatched( projectMock, executionMock, testMojo, cacheRecordMock ),
+                    "If property set to 'skipValue' mismatch could be ignored because cached build"
+                            + " is more complete than requested build" );
+        }
+
+        @Test
+        void testDefaultValue()
+        {
+
+            String propertyName = "anyObject";
+
+            TrackedProperty config = new TrackedProperty();
+            config.setPropertyName( propertyName );
+            config.setDefaultValue( "defaultValue" );
+
+            // value was not cached
+            PropertyValue cache = new PropertyValue();
+            cache.setName( propertyName );
+            cache.setValue( null );
+
+            when( cacheConfigMock.getTrackedProperties( executionMock ) ).thenReturn( Lists.newArrayList( config ) );
+            when( cacheRecordMock.getProperties() ).thenReturn( Lists.newArrayList( cache ) );
+
+            when( projectMock.getBasedir() ).thenReturn( new File( "." ) );
+
+            // emulating that current build is "skipping" something and literal value is different from the cache
+            TestMojo testMojo = new TestMojo();
+            testMojo.setAnyObject( "defaultValue" );
+
+            assertTrue( strategy.isParamsMatched( projectMock, executionMock, testMojo, cacheRecordMock ),
+                    "If property has defaultValue it must be matched even if cache record has no this field" );
+        }
+
+        @Test
+        void testMismatch()
+        {
+
+            String propertyName = "anyObject";
+
+            TrackedProperty config = new TrackedProperty();
+            config.setPropertyName( propertyName );
+
+            // value was not cached
+            PropertyValue cache = new PropertyValue();
+            cache.setName( propertyName );
+            cache.setValue( "1" );
+
+            when( cacheConfigMock.getTrackedProperties( executionMock ) ).thenReturn( Lists.newArrayList( config ) );
+            when( cacheRecordMock.getProperties() ).thenReturn( Lists.newArrayList( cache ) );
+
+            when( projectMock.getBasedir() ).thenReturn( new File( "." ) );
+
+            // emulating that current build is "skipping" something and literal value is different from the cache
+            TestMojo testMojo = new TestMojo();
+            testMojo.setAnyObject( "2" );
+
+            assertFalse( strategy.isParamsMatched( projectMock, executionMock, testMojo, cacheRecordMock ) );
+        }
+
+        @NotNull
+        private Pair<TrackedProperty, PropertyValue> setupProperty( String propertyName, String value )
+        {
+            TrackedProperty config = new TrackedProperty();
+            config.setPropertyName( propertyName );
+
+            PropertyValue cache = new PropertyValue();
+            cache.setName( propertyName );
+            cache.setValue( value );
+
+            return Pair.of( config, cache );
+        }
+    }
+
+}

--- a/src/test/java/org/apache/maven/buildcache/LifecyclePhasesHelperTest.java
+++ b/src/test/java/org/apache/maven/buildcache/LifecyclePhasesHelperTest.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.maven.buildcache;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.buildcache.xml.Build;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.lifecycle.internal.stub.LifecyclesTestUtils;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LifecyclePhasesHelperTest
+{
+
+    private LifecyclePhasesHelper lifecyclePhasesHelper;
+    private MavenProject projectMock;
+    private DefaultLifecycles defaultLifecycles;
+    private Lifecycle cleanLifecycle;
+
+    @BeforeEach
+    void setUp()
+    {
+
+        defaultLifecycles = LifecyclesTestUtils.createDefaultLifecycles();
+        cleanLifecycle = defaultLifecycles.getLifeCycles().stream()
+                .filter( lifecycle -> lifecycle.getId().equals( "clean" ) )
+                .findFirst()
+                .orElseThrow( () -> new RuntimeException( "Clean phase not found" ) );
+
+        MavenSession session = mock( MavenSession.class, RETURNS_DEEP_STUBS );
+        lifecyclePhasesHelper = new LifecyclePhasesHelper( session, defaultLifecycles, cleanLifecycle );
+
+        projectMock = mock( MavenProject.class );
+
+    }
+
+    /**
+     * Checks that the last MojoExecution lifecycle phase is considered the highest
+     */
+    @Test
+    void resolveHighestLifecyclePhaseNormal()
+    {
+        String phase = lifecyclePhasesHelper.resolveHighestLifecyclePhase( projectMock, Lists.newArrayList(
+                mockedMojoExecution( "clean" ), mockedMojoExecution( "compile" ), mockedMojoExecution( "install" ) ) );
+        assertEquals( "install", phase );
+    }
+
+    /**
+     * Checks that for forked execution lifecycle phase is inherited from originating MojoExecution
+     */
+    @Test
+    void resolveHighestLifecyclePhaseForked()
+    {
+
+        MojoExecution origin = mockedMojoExecution( "install" );
+        publishForkedProjectEvent( origin );
+
+        String phase = lifecyclePhasesHelper.resolveHighestLifecyclePhase( projectMock, Lists.newArrayList(
+                mockedMojoExecution( null ) ) );
+
+        assertEquals( "install", phase );
+    }
+
+    /**
+     * Checks proper identification of phases not belonging to clean lifecycle
+     */
+    @Test
+    void isLaterPhaseThanClean()
+    {
+        List<Lifecycle> afterClean = new ArrayList<>( defaultLifecycles.getLifeCycles() );
+
+        assumeTrue( afterClean.remove( cleanLifecycle ) );
+        assumeTrue( afterClean.size() > 0 );
+
+        assertTrue( afterClean.stream().flatMap( it -> it.getPhases().stream() )
+                .allMatch( lifecyclePhasesHelper::isLaterPhaseThanClean ) );
+
+    }
+
+    /**
+     * Checks proper identification of phases belonging to clean lifecycle
+     */
+    @Test
+    void isLaterPhaseThanCleanNegative()
+    {
+        assertTrue( cleanLifecycle.getPhases().stream()
+                .noneMatch( lifecyclePhasesHelper::isLaterPhaseThanClean ) );
+    }
+
+    @Test
+    void isLaterPhaseThanBuild()
+    {
+        List<Lifecycle> afterClean = new ArrayList<>( defaultLifecycles.getLifeCycles() );
+
+        assumeTrue( afterClean.remove( cleanLifecycle ) );
+        assumeTrue( afterClean.size() > 0 );
+
+        Build buildMock = mock( Build.class );
+        when( buildMock.getHighestCompletedGoal() ).thenReturn( "clean" );
+
+        assertTrue( afterClean.stream().flatMap( it -> it.getPhases().stream() )
+                .allMatch( phase -> lifecyclePhasesHelper.isLaterPhaseThanBuild( phase, buildMock ) ) );
+    }
+
+    @Test
+    void isLaterPhaseThanBuildNegative()
+    {
+        List<Lifecycle> afterClean = new ArrayList<>( defaultLifecycles.getLifeCycles() );
+
+        assumeTrue( afterClean.remove( cleanLifecycle ) );
+        assumeTrue( afterClean.size() > 0 );
+
+        Build buildMock = mock( Build.class );
+        when( buildMock.getHighestCompletedGoal() ).thenReturn( "install" );
+
+        assertFalse( afterClean.stream().flatMap( it -> it.getPhases().stream() )
+                .allMatch( phase -> lifecyclePhasesHelper.isLaterPhaseThanBuild( phase, buildMock ) ) );
+    }
+
+    @Test
+    void isLaterPhase()
+    {
+        assertTrue( lifecyclePhasesHelper.isLaterPhase( "install", "compile" ) );
+        assertTrue( lifecyclePhasesHelper.isLaterPhase( "package", "clean" ) );
+        assertTrue( lifecyclePhasesHelper.isLaterPhase( "site", "install" ) );
+        assertFalse( lifecyclePhasesHelper.isLaterPhase( "test", "site" ) );
+        assertFalse( lifecyclePhasesHelper.isLaterPhase( "clean", "site" ) );
+
+        assertThrows( IllegalArgumentException.class, () ->
+        {
+            lifecyclePhasesHelper.isLaterPhase( "install", null );
+        } );
+
+        assertThrows( IllegalArgumentException.class, () ->
+        {
+            lifecyclePhasesHelper.isLaterPhase( "install", "unknown phase" );
+        } );
+
+        assertThrows( IllegalArgumentException.class, () ->
+        {
+            lifecyclePhasesHelper.isLaterPhase( "unknown phase", "install" );
+        } );
+    }
+
+    @Test
+    void getCleanSegment()
+    {
+        MojoExecution clean = mockedMojoExecution( "clean" );
+        List<MojoExecution> cleanSegment = lifecyclePhasesHelper.getCleanSegment( projectMock, Lists.newArrayList(
+                clean,
+                mockedMojoExecution( "compile" ),
+                mockedMojoExecution( "install" ) ) );
+        assertEquals( singletonList( clean ), cleanSegment );
+    }
+
+    /**
+     * checks empty result if no mojos bound to clean lifecycle
+     */
+    @Test
+    void getEmptyCleanSegment()
+    {
+        List<MojoExecution> cleanSegment = lifecyclePhasesHelper.getCleanSegment( projectMock, Lists.newArrayList(
+                mockedMojoExecution( "compile" ),
+                mockedMojoExecution( "install" ) ) );
+        assertEquals( emptyList(), cleanSegment );
+    }
+
+    /**
+     * checks empty result if no mojos bound to clean lifecycle in simulated forked execution
+     */
+    @Test
+    void getEmptyCleanSegmentIfForked()
+    {
+
+        MojoExecution origin = mockedMojoExecution( "install" );
+        publishForkedProjectEvent( origin );
+
+        List<MojoExecution> cleanSegment = lifecyclePhasesHelper.getCleanSegment( projectMock, Lists.newArrayList(
+                // null lifecycle phase is possible in forked executions
+                mockedMojoExecution( null ),
+                mockedMojoExecution( null ) ) );
+
+        assertEquals( emptyList(), cleanSegment );
+    }
+
+    /**
+     * if forked execution lifecycle phase is overridden to originating MojoExecution
+     */
+    @Test
+    void getCleanSegmentForkedAnyLifecyclePhase()
+    {
+        MojoExecution origin = mockedMojoExecution( "install" );
+        publishForkedProjectEvent( origin );
+
+        List<MojoExecution> cleanSegment = lifecyclePhasesHelper.getCleanSegment( projectMock, Lists.newArrayList(
+                // clean is overridden to "install" phase assuming forked execution
+                mockedMojoExecution( "clean" ) ) );
+
+        assertEquals( emptyList(), cleanSegment );
+    }
+
+    @Test
+    void testCachedSegment()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList(
+                compile, test, mockedMojoExecution( "install" ) );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "test" );
+
+        List<MojoExecution> cachedSegment = lifecyclePhasesHelper.getCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertThat( cachedSegment ).containsExactly( compile, test );
+    }
+
+    @Test
+    void testEmptyCachedSegment()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        MojoExecution install = mockedMojoExecution( "install" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList( compile, test, install );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "clean" );
+
+        List<MojoExecution> cachedSegment = lifecyclePhasesHelper.getCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertThat( cachedSegment ).isEmpty();
+    }
+
+    @Test
+    void testCachedSegmentForked()
+    {
+        MojoExecution me1 = mockedMojoExecution( null );
+        MojoExecution me2 = mockedMojoExecution( null );
+
+        List<MojoExecution> mojoExecutions = Lists.newArrayList( me1, me2 );
+
+        MojoExecution origin = mockedMojoExecution( "install" );
+        publishForkedProjectEvent( origin );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "site" );
+
+        List<MojoExecution> cachedSegment = lifecyclePhasesHelper.getCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertEquals( mojoExecutions, cachedSegment );
+    }
+
+    @ParameterizedTest
+    @ValueSource( strings =
+    { "install", "site"
+    } )
+    void testAllInCachedSegment()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        MojoExecution install = mockedMojoExecution( "install" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList( compile, test, install );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "site" );
+
+        List<MojoExecution> cachedSegment = lifecyclePhasesHelper.getCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertEquals( mojoExecutions, cachedSegment );
+    }
+
+    @Test
+    void testPostCachedSegment()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        MojoExecution install = mockedMojoExecution( "install" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList(
+                compile, test, install );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "compile" );
+
+        List<MojoExecution> notCachedSegment = lifecyclePhasesHelper.getPostCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertThat( notCachedSegment ).containsExactly( test, install );
+    }
+
+    @Test
+    void testAllPostCachedSegment()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        MojoExecution install = mockedMojoExecution( "install" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList(
+                compile, test, install );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "clean" );
+
+        List<MojoExecution> notCachedSegment = lifecyclePhasesHelper.getPostCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertThat( notCachedSegment ).isEqualTo( mojoExecutions );
+    }
+
+    @Test
+    void testPostCachedSegmentForked()
+    {
+        MojoExecution me1 = mockedMojoExecution( null );
+        MojoExecution me2 = mockedMojoExecution( null );
+
+        List<MojoExecution> mojoExecutions = Lists.newArrayList( me1, me2 );
+
+        MojoExecution origin = mockedMojoExecution( "install" );
+        publishForkedProjectEvent( origin );
+
+        Build build = mock( Build.class );
+        when( build.getHighestCompletedGoal() ).thenReturn( "package" );
+
+        List<MojoExecution> cachedSegment = lifecyclePhasesHelper.getPostCachedSegment( projectMock, mojoExecutions,
+                build );
+
+        assertThat( cachedSegment ).isEqualTo( mojoExecutions );
+    }
+
+    @ParameterizedTest
+    @ValueSource( strings =
+    { "install", "site"
+    } )
+    void testEmptyPostCachedSegmentInclusive()
+    {
+        MojoExecution compile = mockedMojoExecution( "compile" );
+        MojoExecution test = mockedMojoExecution( "test" );
+        MojoExecution install = mockedMojoExecution( "install" );
+        List<MojoExecution> mojoExecutions = Lists.newArrayList(
+                compile, test, install );
+
+        Build cachedBuild = mock( Build.class );
+        when( cachedBuild.getHighestCompletedGoal() ).thenReturn( "install" );
+
+        List<MojoExecution> notCachedSegment = lifecyclePhasesHelper.getPostCachedSegment( projectMock, mojoExecutions,
+                cachedBuild );
+
+        assertThat( notCachedSegment ).isEmpty();
+    }
+
+    private void publishForkedProjectEvent( MojoExecution origin )
+    {
+
+        ExecutionEvent eventMock = mock( ExecutionEvent.class );
+
+        when( eventMock.getProject() ).thenReturn( projectMock );
+        when( eventMock.getMojoExecution() ).thenReturn( origin );
+        when( eventMock.getType() ).thenReturn( ExecutionEvent.Type.ForkedProjectStarted );
+
+        lifecyclePhasesHelper.forkedProjectStarted( eventMock );
+    }
+
+    @NotNull
+    private static MojoExecution mockedMojoExecution( String phase )
+    {
+        MojoExecution mojoExecution = mock( MojoExecution.class );
+        when( mojoExecution.getLifecyclePhase() ).thenReturn( phase );
+        when( mojoExecution.toString() ).thenReturn( phase );
+        return mojoExecution;
+    }
+
+}

--- a/src/test/java/org/apache/maven/buildcache/TestMojo.java
+++ b/src/test/java/org/apache/maven/buildcache/TestMojo.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.maven.buildcache;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+
+public class TestMojo implements Mojo
+{
+
+    private boolean bool;
+    private int primitive;
+    private File file;
+    private Path path;
+    private List<String> list;
+    private String[] array;
+
+    private Object anyObject;
+    private final Object nullObject = null;
+
+    public TestMojo()
+    {
+    }
+
+    public TestMojo( boolean bool, int primitive, File file, Path path, ArrayList<String> list, String[] array )
+    {
+
+        this.bool = bool;
+        this.primitive = primitive;
+        this.file = file;
+        this.path = path;
+        this.list = list;
+        this.array = array;
+    }
+
+    public static TestMojo create( boolean bool, int primitive, File file, Path path, ArrayList<String> list,
+            String[] array )
+    {
+        return new TestMojo( bool, primitive, file, path, list, array );
+    }
+
+    public boolean isBool()
+    {
+        return bool;
+    }
+
+    public void setBool( boolean bool )
+    {
+        this.bool = bool;
+    }
+
+    public int getPrimitive()
+    {
+        return primitive;
+    }
+
+    public void setPrimitive( int primitive )
+    {
+        this.primitive = primitive;
+    }
+
+    public File getFile()
+    {
+        return file;
+    }
+
+    public void setFile( File file )
+    {
+        this.file = file;
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public void setPath( Path path )
+    {
+        this.path = path;
+    }
+
+    public List<String> getList()
+    {
+        return list;
+    }
+
+    public void setList( List<String> list )
+    {
+        this.list = list;
+    }
+
+    public String[] getArray()
+    {
+        return array;
+    }
+
+    public void setArray( String[] array )
+    {
+        this.array = array;
+    }
+
+    public Object getAnyObject()
+    {
+        return anyObject;
+    }
+
+    public void setAnyObject( Object anyObject )
+    {
+        this.anyObject = anyObject;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException
+    {
+        // do nothing
+    }
+
+    @Override
+    public void setLog( Log log )
+    {
+        // do nothing
+    }
+
+    @Override
+    public Log getLog()
+    {
+        // do nothing
+        return null;
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.maven.buildcache.xml.CacheConfigImpl.CACHE_LOCATION_PROPERTY_NAME;
+
+/**
+ * Runs project which contains plugin with forked execution - pmd
+ * The test checks that extensions receives expected events for forked executions and completes build successfully
+ */
+@IntegrationTest( "src/test/projects/forked-executions-core-extension" )
+public class ForkedExecutionCoreExtensionTest
+{
+
+    private static final String PROJECT_NAME = "org.apache.maven.caching.test.simple:forked-executions-core-extension";
+    private Path tempDirectory;
+
+    @BeforeEach
+    void setUp() throws IOException
+    {
+        tempDirectory = Files.createTempDirectory( "build-cache-test-" );
+    }
+
+    @AfterEach
+    void tearDown() throws IOException
+    {
+        FileUtils.deleteDirectory( tempDirectory.toFile() );
+    }
+
+    @Test
+    void testForkedExecution( Verifier verifier ) throws VerificationException
+    {
+        verifier.setAutoclean( false );
+
+        verifier.setLogFileName( "../log-1.txt" );
+        verifier.setMavenDebug( true );
+        verifier.setCliOptions( Lists.newArrayList(
+                "-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath() ) );
+        verifier.executeGoal( "verify" );
+        verifier.verifyTextInLog( "Started forked project" );
+        verifier.verifyTextInLog( "[INFO] BUILD SUCCESS" );
+
+        verifier.setLogFileName( "../log-2.txt" );
+        verifier.executeGoal( "verify" );
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog( "Found cached build, restoring " + PROJECT_NAME + " from cache" );
+        verifier.verifyTextInLog( "[INFO] BUILD SUCCESS" );
+    }
+
+}

--- a/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
@@ -66,6 +66,10 @@ public class ForkedExecutionCoreExtensionTest
                 "-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath() ) );
         verifier.executeGoal( "verify" );
         verifier.verifyTextInLog( "Started forked project" );
+        verifier.verifyTextInLog(
+                "Mojo execution pmd:pmd:emptyLifecyclePhase:maven-pmd-plugin:org.apache.maven.plugins is forked,"
+                        + " returning phase verify from originating mojo "
+                        + "default:check:verify:maven-pmd-plugin:org.apache.maven.plugins" );
         verifier.verifyTextInLog( "[INFO] BUILD SUCCESS" );
 
         verifier.setLogFileName( "../log-2.txt" );

--- a/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecyclesTestUtils.java
+++ b/src/test/java/org/apache/maven/lifecycle/internal/stub/LifecyclesTestUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.maven.lifecycle.internal.stub;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LifecyclesTestUtils
+{
+
+    public final static MojoDescriptor PRE_CLEAN = createMojoDescriptor( "pre-clean" );
+
+    public final static MojoDescriptor CLEAN = createMojoDescriptor( "clean" );
+
+    public final static MojoDescriptor POST_CLEAN = createMojoDescriptor( "post-clean" );
+
+    // default (or at least some of them)
+
+    public final static MojoDescriptor VALIDATE = createMojoDescriptor( "validate" );
+
+    public final static MojoDescriptor INITIALIZE = createMojoDescriptor( "initialize" );
+
+    public final static MojoDescriptor PROCESS_TEST_RESOURCES = createMojoDescriptor( "process-test-resources" );
+
+    public final static MojoDescriptor PROCESS_RESOURCES = createMojoDescriptor( "process-resources" );
+
+    public final static MojoDescriptor COMPILE = createMojoDescriptor( "compile", true );
+
+    public final static MojoDescriptor TEST_COMPILE = createMojoDescriptor( "test-compile" );
+
+    public final static MojoDescriptor TEST = createMojoDescriptor( "test" );
+
+    public final static MojoDescriptor PACKAGE = createMojoDescriptor( "package" );
+
+    public final static MojoDescriptor INSTALL = createMojoDescriptor( "install" );
+
+    // site
+
+    public final static MojoDescriptor PRE_SITE = createMojoDescriptor( "pre-site" );
+
+    public final static MojoDescriptor SITE = createMojoDescriptor( "site" );
+
+    public final static MojoDescriptor POST_SITE = createMojoDescriptor( "post-site" );
+
+    public final static MojoDescriptor SITE_DEPLOY = createMojoDescriptor( "site-deploy" );
+
+    public static DefaultLifecycles createDefaultLifecycles()
+    {
+
+        List<String> stubDefaultCycle = Arrays.asList( VALIDATE.getPhase(), INITIALIZE.getPhase(),
+                PROCESS_RESOURCES.getPhase(),
+                COMPILE.getPhase(), TEST_COMPILE.getPhase(),
+                TEST.getPhase(), PROCESS_TEST_RESOURCES.getPhase(), PACKAGE.getPhase(), "BEER",
+                INSTALL.getPhase() );
+
+        // The two phases below are really for future expansion, some would say they lack a drink
+        // The point being that they do not really have to match the "real" stuff,
+        List<String> stubCleanCycle = Arrays.asList( PRE_CLEAN.getPhase(), CLEAN.getPhase(), POST_CLEAN.getPhase() );
+
+        List<String> stubSiteCycle = Arrays.asList( PRE_SITE.getPhase(), SITE.getPhase(), POST_SITE.getPhase(),
+                SITE_DEPLOY.getPhase() );
+
+        Map<String, List<String>> stubLifeCycles = new HashMap<>();
+        stubLifeCycles.put( "clean", stubCleanCycle );
+        stubLifeCycles.put( "default", stubDefaultCycle );
+        stubLifeCycles.put( "site", stubSiteCycle );
+
+        List<Lifecycle> matchedLifecycles = Arrays.stream( DefaultLifecycles.STANDARD_LIFECYCLES )
+                .filter( it -> !it.equals( "wrapper" ) )
+                .map( standardLc ->
+                {
+                    assertTrue( stubLifeCycles.containsKey( standardLc ),
+                            "Unsupported standard lifecycle: " + standardLc );
+                    return new Lifecycle( standardLc, stubLifeCycles.get( standardLc ), null );
+                } ).collect( Collectors.toList() );
+
+        DefaultLifecycles defaultLifecycles = mock( DefaultLifecycles.class );
+        when( defaultLifecycles.getLifeCycles() ).thenReturn( matchedLifecycles );
+        return defaultLifecycles;
+    }
+
+    public static MojoDescriptor createMojoDescriptor( String phaseName )
+    {
+        return createMojoDescriptor( phaseName, false );
+    }
+
+    public static MojoDescriptor createMojoDescriptor( String phaseName, boolean threadSafe )
+    {
+        final MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPhase( phaseName );
+        final PluginDescriptor descriptor = new PluginDescriptor();
+        Plugin plugin = new Plugin();
+        plugin.setArtifactId( "org.apache.maven.test.MavenExecutionPlan" );
+        plugin.setGroupId( "stub-plugin-" + phaseName );
+        descriptor.setPlugin( plugin );
+        descriptor.setArtifactId( "artifact." + phaseName );
+        mojoDescriptor.setPluginDescriptor( descriptor );
+        mojoDescriptor.setThreadSafe( threadSafe );
+        return mojoDescriptor;
+    }
+
+}

--- a/src/test/projects/forked-executions-core-extension/.mvn/extensions.xml
+++ b/src/test/projects/forked-executions-core-extension/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions>
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </extension>
+</extensions>

--- a/src/test/projects/forked-executions-core-extension/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/forked-executions-core-extension/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<cache xmlns="http://maven.apache.org/CACHE-CONFIG/1.0.0">
+
+</cache>

--- a/src/test/projects/forked-executions-core-extension/pom.xml
+++ b/src/test/projects/forked-executions-core-extension/pom.xml
@@ -1,0 +1,81 @@
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.caching.test.simple</groupId>
+    <artifactId>forked-executions-core-extension</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.19.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>pmd</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.wagon</groupId>
+                        <artifactId>wagon-http</artifactId>
+                        <version>3.5.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+<!--            [WARNING] The POM for org.apache.maven.wagon:wagon-http:jar:1.0-beta-6 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for /Users/aashitki/.m2/repository/org/apache/maven/wagon/wagon-http/1.0-beta-6/wagon-http-1.0-beta-6.pom-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.wagon</groupId>-->
+<!--                <artifactId>wagon-http</artifactId>-->
+<!--                <version>3.5.2</version>-->
+<!--            </plugin>-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.wagon</groupId>-->
+<!--                <artifactId>wagon-http-shared</artifactId>-->
+<!--                <version>3.5.2</version>-->
+<!--            </plugin>-->
+        </plugins>
+    </build>
+
+<!--    <dependencies>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.maven.wagon</groupId>-->
+<!--            <artifactId>wagon-http</artifactId>-->
+<!--            <version>3.5.2</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.maven.wagon</groupId>-->
+<!--            <artifactId>wagon-http-shared</artifactId>-->
+<!--            <version>3.5.2</version>-->
+<!--        </dependency>-->
+<!--    </dependencies>-->
+
+</project>

--- a/src/test/projects/forked-executions-core-extension/src/main/java/org/apache/maven/buildcache/ForkedExecutionClass.java
+++ b/src/test/projects/forked-executions-core-extension/src/main/java/org/apache/maven/buildcache/ForkedExecutionClass.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache;
+
+class ForkedExecutionClass
+{
+
+}


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MBUILDCACHE-24

Current implementation relies on lifecycle phases presence in 
`MojoExecution`. In case of forked execution `MojoExecution#getLifecyclePhase` could return null which result in IAEs in multiples places in cache. Proposed fix is to resolve `lifecyclePhase` from the originating mojo and use it as a lifecycle phase for forked mojos. This looks quite natural, because forked execution are driven by the originating mojo thus belonging to the same phase.
 
Sample exception:
```java
java.lang.IllegalArgumentException: Unsupported phase: null
    at org.apache.maven.buildcache.LifecyclePhasesHelper.isLaterPhase (LifecyclePhasesHelper.java:121)
    at org.apache.maven.buildcache.LifecyclePhasesHelper.isLaterPhaseThanClean (LifecyclePhasesHelper.java:105)
    at org.apache.maven.buildcache.LifecyclePhasesHelper.getCleanSegment (LifecyclePhasesHelper.java:139)
    at org.apache.maven.buildcache.BuildCacheMojosExecutionStrategy.execute (BuildCacheMojosExecutionStrategy.java:101)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.executeForkedExecutions (MojoExecutor.java:366)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:211)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:167)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:66)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:158)
    at org.apache.maven.buildcache.BuildCacheMojosExecutionStrategy.execute (BuildCacheMojosExecutionStrategy.java:127)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
```

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
