### PR TITLE
docs: fix build-cache dir name in getting-started

### DIFF
--- a/src/site/markdown/getting-started.md
+++ b/src/site/markdown/getting-started.md
@@ -57,7 +57,7 @@ Having extension run usual command, like `mvn package`. Verify the caching engin
   ```
   [INFO] Loading cache configuration from <project dir>/.mvn/maven-build-cache-config.xml
   ```
-* Navigate to your local repo directory - there should be a sibling directory `cache` next to the usual
+* Navigate to your local repo directory - there should be a sibling directory `build-cache` next to the usual
   local `repository`.
 * Find `buildinfo.xml` in the cache repository for typical module and review it. Ensure that
   * expected source code files are present in the build info


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/



**Change Description:**
The actual cache directory generated in `.m2` directory is `build-cache` instead of `cache`. This PR fixes the getting-started document to reference correct directory name.


