### PR TITLE
[MBUILDCACHE-44] fixed issue with duplicate maven phases failing cache

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/xml/Build.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/Build.java
@@ -169,7 +169,8 @@ public class Build {
             execMap = Collections.emptyMap();
             return execMap;
         }
-        execMap = executionsList.stream().collect(Collectors.toMap(CompletedExecution::getExecutionKey, v -> v));
+        execMap = executionsList.stream()
+                .collect(Collectors.toMap(CompletedExecution::getExecutionKey, v -> v, (oldV, newV) -> oldV));
         return execMap;
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/DuplicateGoalsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/DuplicateGoalsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import java.util.Arrays;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest("src/test/projects/duplicate-goals")
+public class DuplicateGoalsTest {
+
+    private static final String PROJECT_NAME = "org.apache.maven.caching.test.goals:duplicate";
+
+    @Test
+    void simple(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        // run with an extra goal
+        verifier.setLogFileName("../log-1.txt");
+        verifier.setMavenDebug(true);
+        verifier.executeGoals(Arrays.asList("compile", "test"));
+        verifier.verifyErrorFreeLog();
+
+        //
+        verifier.setLogFileName("../log-2.txt");
+        verifier.executeGoal("test");
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Found cached build, restoring " + PROJECT_NAME + " from cache");
+    }
+}

--- a/src/test/projects/duplicate-goals/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/duplicate-goals/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<cache xmlns="http://maven.apache.org/CACHE-CONFIG/1.0.0">
+
+</cache>

--- a/src/test/projects/duplicate-goals/pom.xml
+++ b/src/test/projects/duplicate-goals/pom.xml
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.caching.test.goals</groupId>
+    <artifactId>duplicate</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.extensions</groupId>
+                <artifactId>maven-build-cache-extension</artifactId>
+                <version>${projectVersion}</version>
+            </extension>
+        </extensions>
+    </build>
+
+</project>

--- a/src/test/projects/duplicate-goals/src/main/java/org/apache/maven/buildcache/Test.java
+++ b/src/test/projects/duplicate-goals/src/main/java/org/apache/maven/buildcache/Test.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache;
+
+class Test
+{
+
+}


### PR DESCRIPTION
Reproduced the issue with an integration test, applied a fix (via deduplication of info of executions) and created a test that proves issue is now gone.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MNG) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MNG-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MNG-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
