### PR TITLE
[PR-105] Regression : direct input files located in target (usually s…

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/checksum/exclude/ExclusionResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/exclude/ExclusionResolver.java
@@ -138,17 +138,22 @@ public class ExclusionResolver {
         // target/test-classes by default
         Path testOutputDirectoryPath = absoluteNormalizedPath(build.getTestOutputDirectory());
 
-        directoryExclusions.add(
+        addFileAndDirectoryExclusion(
                 new Exclusion(buildDirectoryPath, Exclusion.MatcherType.FILENAME, Exclusion.EntryType.ALL));
 
         if (!outputDirectoryPath.startsWith(buildDirectoryPath)) {
-            directoryExclusions.add(
+            addFileAndDirectoryExclusion(
                     new Exclusion(outputDirectoryPath, Exclusion.MatcherType.FILENAME, Exclusion.EntryType.ALL));
         }
         if (!testOutputDirectoryPath.startsWith(buildDirectoryPath)) {
-            directoryExclusions.add(
+            addFileAndDirectoryExclusion(
                     new Exclusion(testOutputDirectoryPath, Exclusion.MatcherType.FILENAME, Exclusion.EntryType.ALL));
         }
+    }
+
+    private void addFileAndDirectoryExclusion(final Exclusion exclusion) {
+        directoryExclusions.add(exclusion);
+        filesExclusions.add(exclusion);
     }
 
     private Path absoluteNormalizedPath(String directory) {

--- a/src/test/projects/include-exclude/assembly-sources.xml
+++ b/src/test/projects/include-exclude/assembly-sources.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>sources</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src</directory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/test/projects/include-exclude/pom.xml
+++ b/src/test/projects/include-exclude/pom.xml
@@ -51,6 +51,54 @@
                 <version>${projectVersion}</version>
             </extension>
         </extensions>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <!-- zip sources -->
+                        <id>make-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>assembly-sources.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/copy-of-zip</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>${project.build.directory}/include-exclude-${project.version}-sources.zip</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
Regression : direct input files located in target (usually scanned via scanning plugins configurations) are not correctly excluded.

This PR includes the fix + the IT enhancement to test the case.

Sincerely yours,
Kevin

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [MBUILDCACHE JIRA issue](https://issues.apache.org/jira/browse/MBUILDCACHE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
