### PR TITLE
[MBUILDCACHE-71] Store the build info after storing the artifacts.

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -500,7 +500,6 @@ public class CacheControllerImpl implements CacheController {
 
             // if package phase presence means new artifacts were packaged
             if (project.hasLifecyclePhase("package")) {
-                localCache.saveBuildInfo(cacheResult, build);
                 if (projectArtifact.getFile() != null) {
                     localCache.saveArtifactFile(cacheResult, projectArtifact);
                 }
@@ -518,9 +517,9 @@ public class CacheControllerImpl implements CacheController {
                         }
                     }
                 }
-            } else {
-                localCache.saveBuildInfo(cacheResult, build);
             }
+
+            localCache.saveBuildInfo(cacheResult, build);
 
             if (cacheConfig.isBaselineDiffEnabled()) {
                 produceDiffReport(cacheResult, build);


### PR DESCRIPTION
This is done for 2 reasons:
1) To prevent a race condition where build X is storing the build info and build Y is pulling that info and attempting to use the artifacts before build X stored them.

2) When a build is killed (for any reason) after the build info is stored but before the artifacts are stored, a later build will attempt to use the non-existing artifacts.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)