### PR TITLE
[MBUILDCACHE-88] Fix tests execution on jdk > 20

### DIFF
--- a/.github/workflows/maven-verify-3.9.x.yml
+++ b/.github/workflows/maven-verify-3.9.x.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven3"'
       maven-matrix: '[ "3.9.5", "4.0.0-alpha-8" ]'
-      jdk-matrix: '[ "11", "17" ]'
+      jdk-matrix: '[ "11", "17", "21" ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -28,6 +28,6 @@ jobs:
     with:
       maven-args: '-D"maven.test.redirectTestOutputToFile=false"'
       maven-matrix: '[ "3.9.5", "4.0.0-alpha-8" ]'
-      jdk-matrix: '[ "11", "17" ]'
+      jdk-matrix: '[ "11", "17", "21" ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpStdBuild( 'jdks' : [ "11", "17" ] )
+asfMavenTlpStdBuild( 'jdks' : [ "11", "17", "21" ] )


### PR DESCRIPTION
The project tests cannot be run on a jdk21. See : https://issues.apache.org/jira/browse/MBUILDCACHE-88

Please not that this fix does not address the comment line 123 of `CacheConfigImplTest.class` : 

`// unfortunate and potentially fragile deep mocking, but helps avoid most disk involvement while working around
 // the static nio Files.exists method`

The mock implementation can still be considered as fragile.

--------------------------------------------------------------

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [MBUILDCACHE JIRA issue](https://issues.apache.org/jira/browse/MBUILDCACHE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MBUILDCACHE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MBUILDCACHE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
