### PR TITLE
Fix typo in maven-build-cache-config.xml

### DIFF
--- a/src/site/resources/maven-build-cache-config.xml
+++ b/src/site/resources/maven-build-cache-config.xml
@@ -43,7 +43,7 @@
             </glob>
             <includes>
                 <!-- By default, project sources and resources directories are included (src/main/java and src/main/resources) -->
-                <!-- In this example, the goal is to include a widder range of src directories (like src/main/assembly or src/main/groovy) -->
+                <!-- In this example, the goal is to include a wider range of src directories (like src/main/assembly or src/main/groovy) -->
                 <include>src/</include>
             </includes>
             <excludes>


### PR DESCRIPTION
Hi all!

This is a one character typo fix in the site docs. I have read the PR template and I have not created a ticket in the [MBUILDCACHE](https://issues.apache.org/jira/browse/MBUILDCACHE) project.

## License acknowledgement

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)