### PR TITLE
Adds tip that Nexus Repository can be used for a remote cache provider.

### DIFF
--- a/src/site/markdown/getting-started.md.vm
+++ b/src/site/markdown/getting-started.md.vm
@@ -78,6 +78,7 @@ by [Maven Resolver](https://maven.apache.org/resolver/) will suffice. In the sim
 server
 supporting get/put operations. Working examples:
 
+* Sonatype Nexus Repository (raw repository)
 * Artifactory (generic repository)
 * [Nginx OSS](http://nginx.org/en/) with fs module
 


### PR DESCRIPTION
Trivial documentation update to add Nexus Repository as a remote cache provider.