### PR TITLE
Missing compile source roots matching 'generated-sources' and 'generated-test-sources' when compiler is skipped

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -892,6 +892,18 @@ public class CacheControllerImpl implements CacheController {
             Files.createDirectories(outputDir);
         }
         CacheUtils.unzip(artifactFilePath, outputDir);
+        OutputType outputType = OutputType.fromClassifier(artifact.getClassifier());
+        if (outputType != OutputType.GENERATED_SOURCE) {
+            return;
+        }
+        Path targetDir = Paths.get(project.getBuild().getDirectory());
+        if (outputDir.equals(targetDir.resolve("generated-sources"))
+                && !project.getCompileSourceRoots().contains(outputDir.toString())) {
+            project.addCompileSourceRoot(outputDir.toString());
+        } else if (outputDir.equals(targetDir.resolve("generated-test-sources"))
+                && !project.getTestCompileSourceRoots().contains(outputDir.toString())) {
+            project.addTestCompileSourceRoot(outputDir.toString());
+        }
     }
 
     // TODO: move to config


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [MBUILDCACHE JIRA issue](https://issues.apache.org/jira/browse/MBUILDCACHE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MBUILDCACHE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MBUILDCACHE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the [Core IT][core-its] successfully.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

[core-its]: https://maven.apache.org/core-its/core-it-suite/
