### PR TITLE
[MBUILDCACHE-123] do not set projectExecutions if cacheState is disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,19 @@ under the License.
           </execution>
         </executions>
       </plugin>
+      <!-- mvn sisu:main-index to generate META-INF/sisu/javax.inject.Named -->
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-index</id>
+            <goals>
+              <goal>main-index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Revised content:
1. modified ```MojoParametersListener#beforeMojoExecution```: got cacheState and don't allocate projectExecutions memory if cacheState is disabled.
2. added sisu-maven-plugin to pom.xml for generating ```META-INF/sisu/javax.inject.Named``` which should be included in the maven extension jar.

Cause:
if set maven-build-cache-extension at ```.mvn/extensions.xml```, MojoParametersListener will always allocate memory for saving projectExecutions even disable the cache by ```-Dmaven.build.cache.enabled=false```
![0880888504108086c904](https://github.com/user-attachments/assets/7ab0c63a-cab5-47fb-9bdc-2b4cc2756b55)

this pr is related to 
https://issues.apache.org/jira/browse/MBUILDCACHE-123 and https://github.com/apache/dubbo/issues/15328