### PR TITLE
Add ignorePattern attribute to TrackedProperty for array filtering

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
@@ -271,7 +271,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
     private List<GoalReconciliation> getDefaultReconciliationConfigs() {
         List<GoalReconciliation> defaults = new ArrayList<>();
 
-        // maven-compiler-plugin:compile - track source, target, release
+        // maven-compiler-plugin:compile - track source, target, release, compilerArgs
         GoalReconciliation compilerCompile = new GoalReconciliation();
         compilerCompile.setArtifactId("maven-compiler-plugin");
         compilerCompile.setGoal("compile");
@@ -288,9 +288,15 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         release.setPropertyName("release");
         compilerCompile.addReconcile(release);
 
+        // Track compilerArgs but filter out --module-version to handle Maven 4 auto-injection (issue #375)
+        TrackedProperty compilerArgs = new TrackedProperty();
+        compilerArgs.setPropertyName("compilerArgs");
+        compilerArgs.setIgnorePattern("--module-version");
+        compilerCompile.addReconcile(compilerArgs);
+
         defaults.add(compilerCompile);
 
-        // maven-compiler-plugin:testCompile - track source, target, release
+        // maven-compiler-plugin:testCompile - track source, target, release, compilerArgs
         GoalReconciliation compilerTestCompile = new GoalReconciliation();
         compilerTestCompile.setArtifactId("maven-compiler-plugin");
         compilerTestCompile.setGoal("testCompile");
@@ -306,6 +312,12 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         TrackedProperty testRelease = new TrackedProperty();
         testRelease.setPropertyName("release");
         compilerTestCompile.addReconcile(testRelease);
+
+        // Track compilerArgs but filter out --module-version to handle Maven 4 auto-injection (issue #375)
+        TrackedProperty testCompilerArgs = new TrackedProperty();
+        testCompilerArgs.setPropertyName("compilerArgs");
+        testCompilerArgs.setIgnorePattern("--module-version");
+        compilerTestCompile.addReconcile(testCompilerArgs);
 
         defaults.add(compilerTestCompile);
 

--- a/src/main/mdo/build-cache-config.mdo
+++ b/src/main/mdo/build-cache-config.mdo
@@ -1459,6 +1459,11 @@ under the License.
                     <name>defaultValue</name>
                     <type>String</type>
                 </field>
+                <field xml.attribute="true">
+                    <name>ignorePattern</name>
+                    <type>String</type>
+                    <description>Regular expression pattern to filter out matching values from array/list properties before comparison. Useful for filtering auto-injected values like Maven 4's --module-version</description>
+                </field>
             </fields>
         </class>
     </classes>

--- a/src/site/markdown/how-to.md
+++ b/src/site/markdown/how-to.md
@@ -160,6 +160,17 @@ Add `executionControl/runAlways` section:
     </executionControl>
 ```
 
+### Default Reconciliation Behavior
+
+The build cache extension automatically tracks certain critical plugin properties by default, even without explicit
+`executionControl` configuration:
+
+* **maven-compiler-plugin** (`compile` and `testCompile` goals): Tracks `source`, `target`, and `release` properties
+* **maven-install-plugin** (`install` goal): Tracked to ensure artifacts are installed when needed
+
+This default behavior prevents common cache invalidation issues, particularly in multi-module JPMS (Java Platform Module System)
+projects where compiler version changes can cause compilation failures.
+
 ### I occasionally cached build with `-DskipTests=true`, and tests do not run now
 
 If you add command line flags to your build, they do not participate in effective pom - Maven defers the final value


### PR DESCRIPTION
Fixes #375

## Problem

Maven 4 auto-injects `--module-version ${project.version}` to `compilerArgs` during cache storage but not during validation, causing parameter mismatches and forcing rebuilds on every invocation for modules with `module-info.java`.

## Solution

Add `ignorePattern` attribute to `TrackedProperty` that filters array elements using regex before comparison.

## Changes

1. **MDO Model** (`build-cache-config.mdo`): Add `ignorePattern` field to `TrackedProperty`
2. **Reconciliation Logic** (`BuildCacheMojosExecutionStrategy.java`):
   - `filterAndStringifyArray()` - filters runtime array values before stringification
   - `filterArrayString()` - filters cached string representations
   - Apply filtering to both current and expected values before comparison
3. **Default Configuration** (`CacheConfigImpl.java`): Track `compilerArgs` with `ignorePattern="--module-version"` for both `compile` and `testCompile` goals

## Testing

Tested with multi-module JPMS project using Maven 4.0.0-rc-4:
- ✅ No parameter mismatches with `--module-version` present
- ✅ Cache correctly reused across builds
- ✅ Legitimate `compilerArgs` changes still invalidate cache

## Related Issues

- #375 - Maven 4 --module-version causes cache mismatches