### PR TITLE
Save attached outputs for compile-only cache entries

### DIFF
--- a/src/test/java/org/apache/maven/buildcache/its/Issue393CompileRestoreTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue393CompileRestoreTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import java.util.Arrays;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest("src/test/projects/issue-393-compile-restore")
+class Issue393CompileRestoreTest {
+
+    @Test
+    void restoresAttachedOutputsAfterCompileOnlyBuild(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        verifier.setLogFileName("../log-compile.txt");
+        verifier.executeGoals(Arrays.asList("clean", "compile"));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyFilePresent("app/target/classes/module-info.class");
+        verifier.verifyFilePresent("consumer/target/classes/module-info.class");
+
+        verifier.setLogFileName("../log-verify.txt");
+        verifier.executeGoals(Arrays.asList("clean", "verify"));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Found cached build, restoring org.apache.maven.caching.test.jpms:issue-393-app from cache");
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+
+        verifier.verifyFilePresent("app/target/classes/module-info.class");
+        verifier.verifyFilePresent("consumer/target/classes/module-info.class");
+        verifier.verifyFilePresent("consumer/target/test-classes/org/apache/maven/caching/test/jpms/consumer/ConsumerTest.class");
+    }
+}

--- a/src/test/projects/issue-393-compile-restore/.mvn/extensions.xml
+++ b/src/test/projects/issue-393-compile-restore/.mvn/extensions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to You under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<extensions>
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>${projectVersion}</version>
+    </extension>
+</extensions>

--- a/src/test/projects/issue-393-compile-restore/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/issue-393-compile-restore/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to You under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+    <configuration>
+        <attachedOutputs>
+            <dirNames>
+                <dirName>classes</dirName>
+                <dirName>test-classes</dirName>
+                <dirName>maven-status</dirName>
+            </dirNames>
+        </attachedOutputs>
+    </configuration>
+</cache>

--- a/src/test/projects/issue-393-compile-restore/app/pom.xml
+++ b/src/test/projects/issue-393-compile-restore/app/pom.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to You under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.caching.test.jpms</groupId>
+        <artifactId>issue-393-compile-restore</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue-393-app</artifactId>
+    <name>Issue 393 Compile Restore - App Module</name>
+    <packaging>jar</packaging>
+
+</project>

--- a/src/test/projects/issue-393-compile-restore/app/src/main/java/module-info.java
+++ b/src/test/projects/issue-393-compile-restore/app/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.apache.maven.caching.test.jpms.app {
+    exports org.apache.maven.caching.test.jpms.app;
+}

--- a/src/test/projects/issue-393-compile-restore/app/src/main/java/org/apache/maven/caching/test/jpms/app/Greeting.java
+++ b/src/test/projects/issue-393-compile-restore/app/src/main/java/org/apache/maven/caching/test/jpms/app/Greeting.java
@@ -1,0 +1,12 @@
+package org.apache.maven.caching.test.jpms.app;
+
+public final class Greeting {
+
+    private Greeting() {
+        // utility
+    }
+
+    public static String message() {
+        return "hello from module";
+    }
+}

--- a/src/test/projects/issue-393-compile-restore/consumer/pom.xml
+++ b/src/test/projects/issue-393-compile-restore/consumer/pom.xml
@@ -1,0 +1,64 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to You under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.caching.test.jpms</groupId>
+        <artifactId>issue-393-compile-restore</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue-393-consumer</artifactId>
+    <name>Issue 393 Compile Restore - Consumer Module</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>issue-393-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>true</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/projects/issue-393-compile-restore/consumer/src/main/java/module-info.java
+++ b/src/test/projects/issue-393-compile-restore/consumer/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module org.apache.maven.caching.test.jpms.consumer {
+    requires org.apache.maven.caching.test.jpms.app;
+    exports org.apache.maven.caching.test.jpms.consumer;
+}

--- a/src/test/projects/issue-393-compile-restore/consumer/src/main/java/org/apache/maven/caching/test/jpms/consumer/Consumer.java
+++ b/src/test/projects/issue-393-compile-restore/consumer/src/main/java/org/apache/maven/caching/test/jpms/consumer/Consumer.java
@@ -1,0 +1,14 @@
+package org.apache.maven.caching.test.jpms.consumer;
+
+import org.apache.maven.caching.test.jpms.app.Greeting;
+
+public final class Consumer {
+
+    private Consumer() {
+        // utility
+    }
+
+    public static String message() {
+        return Greeting.message();
+    }
+}

--- a/src/test/projects/issue-393-compile-restore/consumer/src/test/java/org/apache/maven/caching/test/jpms/consumer/ConsumerTest.java
+++ b/src/test/projects/issue-393-compile-restore/consumer/src/test/java/org/apache/maven/caching/test/jpms/consumer/ConsumerTest.java
@@ -1,0 +1,13 @@
+package org.apache.maven.caching.test.jpms.consumer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConsumerTest {
+
+    @Test
+    void messageIsProvidedByUpstreamModule() {
+        assertEquals("hello from module", Consumer.message());
+    }
+}

--- a/src/test/projects/issue-393-compile-restore/pom.xml
+++ b/src/test/projects/issue-393-compile-restore/pom.xml
@@ -1,0 +1,42 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to You under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.caching.test.jpms</groupId>
+    <artifactId>issue-393-compile-restore</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Issue 393 Compile Restore Aggregator</name>
+
+    <modules>
+        <module>app</module>
+        <module>consumer</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+</project>


### PR DESCRIPTION
## Summary
- reset cached-output bookkeeping per save invocation and always attach configured directories before writing the cache entry
- ensure compile-only executions persist the configured outputs so higher lifecycle phases can restore them
- add an integration test project covering JPMS module descriptors after a compile-only cache hit

## Testing
- ./mvnw -Prun-its -Dit.test=Issue393CompileRestoreTest verify

Fixes #393
Relates-To: #259
Relates-To: #340