### PR TITLE
Fix #375: Capture plugin properties at validation time to eliminate timing mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@ under the License.
     <minimalMavenBuildVersion>3.9.0</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <classWorldsVersion>2.6.0</classWorldsVersion>
-    <version.spotless-maven-plugin>3.0.0</version.spotless-maven-plugin>
 
     <!-- default maven version we build against -->
     <mavenVersion>3.9.16</mavenVersion>
@@ -479,17 +478,6 @@ under the License.
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <java>
-            <palantirJavaFormat>
-              <version>2.81.0</version>
-            </palantirJavaFormat>
-          </java>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
     <minimalMavenBuildVersion>3.9.0</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <classWorldsVersion>2.6.0</classWorldsVersion>
+    <version.spotless-maven-plugin>3.0.0</version.spotless-maven-plugin>
 
     <!-- default maven version we build against -->
     <mavenVersion>3.9.16</mavenVersion>
@@ -478,6 +479,17 @@ under the License.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <palantirJavaFormat>
+              <version>2.81.0</version>
+            </palantirJavaFormat>
+          </java>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -24,6 +24,7 @@ import javax.inject.Named;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -202,7 +203,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                                 || result.getValidationTimeEvents().isEmpty()) {
                             throw new AssertionError(
                                     "Validation-time properties not captured for project " + projectName
-                                            + ". This is a bug - validation-time capture should always succeed when saving to cache.");
+                                            + ". This is a bug. Validation-time capture should always succeed when saving to cache.");
                         }
                         LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
                         cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
@@ -477,7 +478,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
      */
     private Map<String, MojoExecutionEvent> captureValidationTimeProperties(
             MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions) {
-        Map<String, MojoExecutionEvent> validationTimeEvents = new java.util.HashMap<>();
+        Map<String, MojoExecutionEvent> validationTimeEvents = new HashMap<>();
 
         for (MojoExecution mojoExecution : mojoExecutions) {
             // Skip mojos that don't execute or are in clean phase
@@ -486,19 +487,22 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                 continue;
             }
 
-            Mojo mojo = null;
             try {
                 mojoExecutionScope.enter();
                 mojoExecutionScope.seed(MavenProject.class, project);
                 mojoExecutionScope.seed(MojoExecution.class, mojoExecution);
 
-                mojo = mavenPluginManager.getConfiguredMojo(Mojo.class, session, mojoExecution);
-                MojoExecutionEvent event = new MojoExecutionEvent(session, project, mojoExecution, mojo);
-                validationTimeEvents.put(mojoExecutionKey(mojoExecution), event);
+                Mojo mojo = mavenPluginManager.getConfiguredMojo(Mojo.class, session, mojoExecution);
+                try {
+                    MojoExecutionEvent event = new MojoExecutionEvent(session, project, mojoExecution, mojo);
+                    validationTimeEvents.put(mojoExecutionKey(mojoExecution), event);
 
-                LOGGER.debug(
-                        "Captured validation-time properties for {}",
-                        mojoExecution.getMojoDescriptor().getFullGoalName());
+                    LOGGER.debug(
+                            "Captured validation-time properties for {}",
+                            mojoExecution.getMojoDescriptor().getFullGoalName());
+                } finally {
+                    mavenPluginManager.releaseMojo(mojo, mojoExecution);
+                }
 
             } catch (PluginConfigurationException | PluginContainerException e) {
                 LOGGER.warn(
@@ -510,9 +514,6 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     mojoExecutionScope.exit();
                 } catch (MojoExecutionException e) {
                     LOGGER.debug("Error exiting mojo execution scope: {}", e.getMessage());
-                }
-                if (mojo != null) {
-                    mavenPluginManager.releaseMojo(mojo, mojoExecution);
                 }
             }
         }

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -134,6 +134,19 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                 }
                 if (cacheState == INITIALIZED) {
                     result = cacheController.findCachedBuild(session, project, mojoExecutions, skipCache);
+
+                    // Capture validation-time properties for all mojos to ensure consistent property reading
+                    // at the same lifecycle point for all builds (eliminates Maven 4 injection timing issues)
+                    // Always capture when cacheState is INITIALIZED since we may need to save
+                    if (cacheState == INITIALIZED) {
+                        Map<String, MojoExecutionEvent> validationTimeEvents =
+                                captureValidationTimeProperties(session, project, mojoExecutions);
+                        result = CacheResult.rebuilded(result, validationTimeEvents);
+                        LOGGER.debug(
+                                "Captured validation-time properties for {} mojos in project {}",
+                                validationTimeEvents.size(),
+                                projectName);
+                    }
                 }
             } else {
                 LOGGER.info("Cache is disabled on project level for {}", projectName);
@@ -183,9 +196,16 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                                     .isEmpty()) {
                         LOGGER.debug("Cache storing is skipped since there was no \"clean\" phase.");
                     } else {
-                        final Map<String, MojoExecutionEvent> executionEvents =
-                                mojoListener.getProjectExecutions(project);
-                        cacheController.save(result, mojoExecutions, executionEvents);
+                        // Validation-time events must exist for cache storage
+                        // If they don't exist, this indicates a bug in the capture logic
+                        if (result.getValidationTimeEvents() == null || result.getValidationTimeEvents().isEmpty()) {
+                            throw new AssertionError(
+                                    "Validation-time properties not captured for project " + projectName
+                                            + ". This is a bug - validation-time capture should always succeed when saving to cache.");
+                        }
+                        LOGGER.debug(
+                                "Using validation-time properties for cache storage (consistent lifecycle point)");
+                        cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
                     }
                 }
             } finally {
@@ -442,6 +462,63 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
             }
         }
         return true;
+    }
+
+    /**
+     * Captures plugin properties at validation time for all mojo executions.
+     * This ensures properties are read at the same lifecycle point for all builds,
+     * eliminating timing mismatches caused by Maven 4's auto-injection of properties
+     * like --module-version during execution.
+     *
+     * @param session Maven session
+     * @param project Current project
+     * @param mojoExecutions List of mojo executions to capture properties for
+     * @return Map of execution key to MojoExecutionEvent captured at validation time
+     */
+    private Map<String, MojoExecutionEvent> captureValidationTimeProperties(
+            MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions) {
+        Map<String, MojoExecutionEvent> validationTimeEvents = new java.util.HashMap<>();
+
+        for (MojoExecution mojoExecution : mojoExecutions) {
+            // Skip mojos that don't execute or are in clean phase
+            if (mojoExecution.getLifecyclePhase() == null
+                    || !lifecyclePhasesHelper.isLaterPhaseThanClean(mojoExecution.getLifecyclePhase())) {
+                continue;
+            }
+
+            Mojo mojo = null;
+            try {
+                mojoExecutionScope.enter();
+                mojoExecutionScope.seed(MavenProject.class, project);
+                mojoExecutionScope.seed(MojoExecution.class, mojoExecution);
+
+                mojo = mavenPluginManager.getConfiguredMojo(Mojo.class, session, mojoExecution);
+                MojoExecutionEvent event = new MojoExecutionEvent(session, project, mojoExecution, mojo);
+                validationTimeEvents.put(mojoExecutionKey(mojoExecution), event);
+
+                LOGGER.debug(
+                        "Captured validation-time properties for {}",
+                        mojoExecution.getMojoDescriptor().getFullGoalName());
+
+            } catch (PluginConfigurationException | PluginContainerException e) {
+                LOGGER.warn(
+                        "Cannot capture validation-time properties for {}: {}",
+                        mojoExecution.getMojoDescriptor().getFullGoalName(),
+                        e.getMessage());
+            } finally {
+                try {
+                    mojoExecutionScope.exit();
+                } catch (MojoExecutionException e) {
+                    LOGGER.debug("Error exiting mojo execution scope: {}", e.getMessage());
+                }
+                if (mojo != null) {
+                    mavenPluginManager.releaseMojo(mojo, mojoExecution);
+                }
+            }
+        }
+
+        LOGGER.debug("Captured validation-time properties for {} mojos", validationTimeEvents.size());
+        return validationTimeEvents;
     }
 
     private enum CacheRestorationStatus {

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -203,7 +203,8 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                                 || result.getValidationTimeEvents().isEmpty()) {
                             LOGGER.debug("Skipping cache storage for {} - no cacheable mojos executed", projectName);
                         } else {
-                            LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
+                            LOGGER.debug(
+                                    "Using validation-time properties for cache storage (consistent lifecycle point)");
                             cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
                         }
                     }

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -101,6 +101,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
             List<MojoExecution> mojoExecutions, MavenSession session, MojoExecutionRunner mojoExecutionRunner)
             throws LifecycleExecutionException {
 
+        Map<String, MojoExecutionEvent> validationTimeEvents = null;
         try {
             final MavenProject project = session.getCurrentProject();
             final Source source = getSource(mojoExecutions);
@@ -139,8 +140,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     // Capture validation-time properties for all mojos to ensure consistent property reading
                     // at the same lifecycle point for all builds (eliminates Maven 4 injection timing issues)
                     // Always capture when cacheState is INITIALIZED since we may need to save
-                    Map<String, MojoExecutionEvent> validationTimeEvents =
-                            captureValidationTimeProperties(session, project, mojoExecutions);
+                    validationTimeEvents = captureValidationTimeProperties(session, project, mojoExecutions);
                     result = CacheResult.rebuilded(result, validationTimeEvents);
                     LOGGER.debug(
                             "Captured validation-time properties for {} mojos in project {}",
@@ -224,6 +224,8 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
             }
         } catch (MojoExecutionException e) {
             throw new LifecycleExecutionException(e.getMessage(), e);
+        } finally {
+            releaseValidationTimeMojos(validationTimeEvents);
         }
     }
 
@@ -480,46 +482,54 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
             throws LifecycleExecutionException {
         Map<String, MojoExecutionEvent> validationTimeEvents = new HashMap<>();
 
-        for (MojoExecution mojoExecution : mojoExecutions) {
-            // Skip mojos that don't execute or are in clean phase
-            if (mojoExecution.getLifecyclePhase() == null
-                    || !lifecyclePhasesHelper.isLaterPhaseThanClean(mojoExecution.getLifecyclePhase())) {
-                continue;
-            }
+        try {
+            for (MojoExecution mojoExecution : mojoExecutions) {
+                // Skip mojos that don't execute or are in clean phase
+                if (mojoExecution.getLifecyclePhase() == null
+                        || !lifecyclePhasesHelper.isLaterPhaseThanClean(mojoExecution.getLifecyclePhase())) {
+                    continue;
+                }
 
-            mojoExecutionScope.enter();
-            try {
-                mojoExecutionScope.seed(MavenProject.class, project);
-                mojoExecutionScope.seed(MojoExecution.class, mojoExecution);
-
-                Mojo mojo = mavenPluginManager.getConfiguredMojo(Mojo.class, session, mojoExecution);
+                mojoExecutionScope.enter();
                 try {
+                    mojoExecutionScope.seed(MavenProject.class, project);
+                    mojoExecutionScope.seed(MojoExecution.class, mojoExecution);
+
+                    Mojo mojo = mavenPluginManager.getConfiguredMojo(Mojo.class, session, mojoExecution);
                     MojoExecutionEvent event = new MojoExecutionEvent(session, project, mojoExecution, mojo);
                     validationTimeEvents.put(mojoExecutionKey(mojoExecution), event);
 
                     LOGGER.debug(
                             "Captured validation-time properties for {}",
                             mojoExecution.getMojoDescriptor().getFullGoalName());
+                } catch (PluginConfigurationException | PluginContainerException e) {
+                    throw new LifecycleExecutionException(
+                            "Cannot capture validation-time properties for "
+                                    + mojoExecution.getMojoDescriptor().getFullGoalName(),
+                            e);
                 } finally {
-                    mavenPluginManager.releaseMojo(mojo, mojoExecution);
-                }
-
-            } catch (PluginConfigurationException | PluginContainerException e) {
-                throw new LifecycleExecutionException(
-                        "Cannot capture validation-time properties for "
-                                + mojoExecution.getMojoDescriptor().getFullGoalName(),
-                        e);
-            } finally {
-                try {
-                    mojoExecutionScope.exit();
-                } catch (MojoExecutionException e) {
-                    LOGGER.debug("Error exiting mojo execution scope: {}", e.getMessage());
+                    try {
+                        mojoExecutionScope.exit();
+                    } catch (MojoExecutionException e) {
+                        LOGGER.debug("Error exiting mojo execution scope: {}", e.getMessage());
+                    }
                 }
             }
+        } catch (LifecycleExecutionException e) {
+            releaseValidationTimeMojos(validationTimeEvents);
+            throw e;
         }
 
         LOGGER.debug("Captured validation-time properties for {} mojos", validationTimeEvents.size());
         return validationTimeEvents;
+    }
+
+    private void releaseValidationTimeMojos(Map<String, MojoExecutionEvent> validationTimeEvents) {
+        if (validationTimeEvents != null) {
+            for (MojoExecutionEvent event : validationTimeEvents.values()) {
+                mavenPluginManager.releaseMojo(event.getMojo(), event.getExecution());
+            }
+        }
     }
 
     private void validateValidationTimeEvents(

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -201,8 +201,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                         // When running only clean phase, there are no cacheable mojos
                         if (result.getValidationTimeEvents() == null
                                 || result.getValidationTimeEvents().isEmpty()) {
-                            LOGGER.debug(
-                                    "Skipping cache storage for {} - no cacheable mojos executed", projectName);
+                            LOGGER.debug("Skipping cache storage for {} - no cacheable mojos executed", projectName);
                         } else {
                             LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
                             cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -198,13 +198,13 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     } else {
                         // Validation-time events must exist for cache storage
                         // If they don't exist, this indicates a bug in the capture logic
-                        if (result.getValidationTimeEvents() == null || result.getValidationTimeEvents().isEmpty()) {
+                        if (result.getValidationTimeEvents() == null
+                                || result.getValidationTimeEvents().isEmpty()) {
                             throw new AssertionError(
                                     "Validation-time properties not captured for project " + projectName
                                             + ". This is a bug - validation-time capture should always succeed when saving to cache.");
                         }
-                        LOGGER.debug(
-                                "Using validation-time properties for cache storage (consistent lifecycle point)");
+                        LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
                         cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
                     }
                 }

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -199,6 +199,7 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     } else {
                         // Only save cache if there are validation-time events to store
                         // When running only clean phase, there are no cacheable mojos
+                        validateValidationTimeEvents(projectName, mojoExecutions, result.getValidationTimeEvents());
                         if (result.getValidationTimeEvents() == null
                                 || result.getValidationTimeEvents().isEmpty()) {
                             LOGGER.debug("Skipping cache storage for {} - no cacheable mojos executed", projectName);
@@ -477,7 +478,8 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
      * @return Map of execution key to MojoExecutionEvent captured at validation time
      */
     private Map<String, MojoExecutionEvent> captureValidationTimeProperties(
-            MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions) {
+            MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions)
+            throws LifecycleExecutionException {
         Map<String, MojoExecutionEvent> validationTimeEvents = new HashMap<>();
 
         for (MojoExecution mojoExecution : mojoExecutions) {
@@ -505,10 +507,10 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                 }
 
             } catch (PluginConfigurationException | PluginContainerException e) {
-                LOGGER.warn(
-                        "Cannot capture validation-time properties for {}: {}",
-                        mojoExecution.getMojoDescriptor().getFullGoalName(),
-                        e.getMessage());
+                throw new LifecycleExecutionException(
+                        "Cannot capture validation-time properties for "
+                                + mojoExecution.getMojoDescriptor().getFullGoalName(),
+                        e);
             } finally {
                 try {
                     mojoExecutionScope.exit();
@@ -520,6 +522,20 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
 
         LOGGER.debug("Captured validation-time properties for {} mojos", validationTimeEvents.size());
         return validationTimeEvents;
+    }
+
+    private void validateValidationTimeEvents(
+            String projectName,
+            List<MojoExecution> mojoExecutions,
+            Map<String, MojoExecutionEvent> validationTimeEvents) {
+        for (MojoExecution mojoExecution : mojoExecutions) {
+            if (mojoExecution.getLifecyclePhase() != null
+                    && lifecyclePhasesHelper.isLaterPhaseThanClean(mojoExecution.getLifecyclePhase())
+                    && (validationTimeEvents == null
+                            || !validationTimeEvents.containsKey(mojoExecutionKey(mojoExecution)))) {
+                throw new AssertionError("Validation-time properties not captured for project " + projectName);
+            }
+        }
     }
 
     private enum CacheRestorationStatus {

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -139,15 +139,13 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     // Capture validation-time properties for all mojos to ensure consistent property reading
                     // at the same lifecycle point for all builds (eliminates Maven 4 injection timing issues)
                     // Always capture when cacheState is INITIALIZED since we may need to save
-                    if (cacheState == INITIALIZED) {
-                        Map<String, MojoExecutionEvent> validationTimeEvents =
-                                captureValidationTimeProperties(session, project, mojoExecutions);
-                        result = CacheResult.rebuilded(result, validationTimeEvents);
-                        LOGGER.debug(
-                                "Captured validation-time properties for {} mojos in project {}",
-                                validationTimeEvents.size(),
-                                projectName);
-                    }
+                    Map<String, MojoExecutionEvent> validationTimeEvents =
+                            captureValidationTimeProperties(session, project, mojoExecutions);
+                    result = CacheResult.rebuilded(result, validationTimeEvents);
+                    LOGGER.debug(
+                            "Captured validation-time properties for {} mojos in project {}",
+                            validationTimeEvents.size(),
+                            projectName);
                 }
             } else {
                 LOGGER.info("Cache is disabled on project level for {}", projectName);
@@ -489,8 +487,8 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                 continue;
             }
 
+            mojoExecutionScope.enter();
             try {
-                mojoExecutionScope.enter();
                 mojoExecutionScope.seed(MavenProject.class, project);
                 mojoExecutionScope.seed(MojoExecution.class, mojoExecution);
 
@@ -533,7 +531,10 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                     && lifecyclePhasesHelper.isLaterPhaseThanClean(mojoExecution.getLifecyclePhase())
                     && (validationTimeEvents == null
                             || !validationTimeEvents.containsKey(mojoExecutionKey(mojoExecution)))) {
-                throw new AssertionError("Validation-time properties not captured for project " + projectName);
+                throw new AssertionError("Validation-time properties not captured for "
+                        + mojoExecution.getMojoDescriptor().getFullGoalName()
+                        + " in project "
+                        + projectName);
             }
         }
     }

--- a/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
+++ b/src/main/java/org/apache/maven/buildcache/BuildCacheMojosExecutionStrategy.java
@@ -197,16 +197,16 @@ public class BuildCacheMojosExecutionStrategy implements MojosExecutionStrategy 
                                     .isEmpty()) {
                         LOGGER.debug("Cache storing is skipped since there was no \"clean\" phase.");
                     } else {
-                        // Validation-time events must exist for cache storage
-                        // If they don't exist, this indicates a bug in the capture logic
+                        // Only save cache if there are validation-time events to store
+                        // When running only clean phase, there are no cacheable mojos
                         if (result.getValidationTimeEvents() == null
                                 || result.getValidationTimeEvents().isEmpty()) {
-                            throw new AssertionError(
-                                    "Validation-time properties not captured for project " + projectName
-                                            + ". This is a bug. Validation-time capture should always succeed when saving to cache.");
+                            LOGGER.debug(
+                                    "Skipping cache storage for {} - no cacheable mojos executed", projectName);
+                        } else {
+                            LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
+                            cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
                         }
-                        LOGGER.debug("Using validation-time properties for cache storage (consistent lifecycle point)");
-                        cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
                     }
                 }
             } finally {

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -157,7 +157,7 @@ public class CacheResult {
         return build != null && build.getDto().is_final();
     }
 
-    public Map<String, MojoExecutionEvent> getValidationTimeEvents() {
+    Map<String, MojoExecutionEvent> getValidationTimeEvents() {
         return validationTimeEvents;
     }
 }

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -18,8 +18,11 @@
  */
 package org.apache.maven.buildcache;
 
+import java.util.Map;
+
 import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.CacheSource;
+import org.apache.maven.execution.MojoExecutionEvent;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,49 +34,79 @@ public class CacheResult {
     private final RestoreStatus status;
     private final Build build;
     private final CacheContext context;
+    private final Map<String, MojoExecutionEvent> validationTimeEvents;
 
-    private CacheResult(RestoreStatus status, Build build, CacheContext context) {
+    private CacheResult(RestoreStatus status, Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
         this.status = requireNonNull(status);
         this.build = build;
         this.context = context;
+        this.validationTimeEvents = validationTimeEvents;
     }
 
     public static CacheResult empty(CacheContext context) {
         requireNonNull(context);
-        return new CacheResult(RestoreStatus.EMPTY, null, context);
+        return new CacheResult(RestoreStatus.EMPTY, null, context, null);
+    }
+
+    public static CacheResult empty(CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(context);
+        return new CacheResult(RestoreStatus.EMPTY, null, context, validationTimeEvents);
     }
 
     public static CacheResult empty() {
-        return new CacheResult(RestoreStatus.EMPTY, null, null);
+        return new CacheResult(RestoreStatus.EMPTY, null, null, null);
     }
 
     public static CacheResult failure(Build build, CacheContext context) {
         requireNonNull(build);
         requireNonNull(context);
-        return new CacheResult(RestoreStatus.FAILURE, build, context);
+        return new CacheResult(RestoreStatus.FAILURE, build, context, null);
+    }
+
+    public static CacheResult failure(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(build);
+        requireNonNull(context);
+        return new CacheResult(RestoreStatus.FAILURE, build, context, validationTimeEvents);
     }
 
     public static CacheResult success(Build build, CacheContext context) {
         requireNonNull(build);
         requireNonNull(context);
-        return new CacheResult(RestoreStatus.SUCCESS, build, context);
+        return new CacheResult(RestoreStatus.SUCCESS, build, context, null);
+    }
+
+    public static CacheResult success(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(build);
+        requireNonNull(context);
+        return new CacheResult(RestoreStatus.SUCCESS, build, context, validationTimeEvents);
     }
 
     public static CacheResult partialSuccess(Build build, CacheContext context) {
         requireNonNull(build);
         requireNonNull(context);
-        return new CacheResult(RestoreStatus.PARTIAL, build, context);
+        return new CacheResult(RestoreStatus.PARTIAL, build, context, null);
+    }
+
+    public static CacheResult partialSuccess(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(build);
+        requireNonNull(context);
+        return new CacheResult(RestoreStatus.PARTIAL, build, context, validationTimeEvents);
     }
 
     public static CacheResult failure(CacheContext context) {
         requireNonNull(context);
-        return new CacheResult(RestoreStatus.FAILURE, null, context);
+        return new CacheResult(RestoreStatus.FAILURE, null, context, null);
+    }
+
+    public static CacheResult failure(CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(context);
+        return new CacheResult(RestoreStatus.FAILURE, null, context, validationTimeEvents);
     }
 
     public static CacheResult rebuilt(CacheResult original, Build build) {
         requireNonNull(original);
         requireNonNull(build);
-        return new CacheResult(original.status, build, original.context);
+        return new CacheResult(original.status, build, original.context, original.validationTimeEvents);
     }
 
     /**
@@ -82,6 +115,11 @@ public class CacheResult {
     @Deprecated
     public static CacheResult rebuilded(CacheResult original, Build build) {
         return rebuilt(original, build);
+    }
+
+    public static CacheResult rebuilded(CacheResult original, Map<String, MojoExecutionEvent> validationTimeEvents) {
+        requireNonNull(original);
+        return new CacheResult(original.status, original.build, original.context, validationTimeEvents);
     }
 
     public boolean isSuccess() {
@@ -110,5 +148,9 @@ public class CacheResult {
 
     public boolean isFinal() {
         return build != null && build.getDto().is_final();
+    }
+
+    public Map<String, MojoExecutionEvent> getValidationTimeEvents() {
+        return validationTimeEvents;
     }
 }

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -36,7 +36,11 @@ public class CacheResult {
     private final CacheContext context;
     private final Map<String, MojoExecutionEvent> validationTimeEvents;
 
-    private CacheResult(RestoreStatus status, Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+    private CacheResult(
+            RestoreStatus status,
+            Build build,
+            CacheContext context,
+            Map<String, MojoExecutionEvent> validationTimeEvents) {
         this.status = requireNonNull(status);
         this.build = build;
         this.context = context;
@@ -63,7 +67,8 @@ public class CacheResult {
         return new CacheResult(RestoreStatus.FAILURE, build, context, null);
     }
 
-    public static CacheResult failure(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+    public static CacheResult failure(
+            Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
         requireNonNull(build);
         requireNonNull(context);
         return new CacheResult(RestoreStatus.FAILURE, build, context, validationTimeEvents);
@@ -75,7 +80,8 @@ public class CacheResult {
         return new CacheResult(RestoreStatus.SUCCESS, build, context, null);
     }
 
-    public static CacheResult success(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+    public static CacheResult success(
+            Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
         requireNonNull(build);
         requireNonNull(context);
         return new CacheResult(RestoreStatus.SUCCESS, build, context, validationTimeEvents);
@@ -87,7 +93,8 @@ public class CacheResult {
         return new CacheResult(RestoreStatus.PARTIAL, build, context, null);
     }
 
-    public static CacheResult partialSuccess(Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
+    public static CacheResult partialSuccess(
+            Build build, CacheContext context, Map<String, MojoExecutionEvent> validationTimeEvents) {
         requireNonNull(build);
         requireNonNull(context);
         return new CacheResult(RestoreStatus.PARTIAL, build, context, validationTimeEvents);

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -157,7 +157,7 @@ public class CacheResult {
         return build != null && build.getDto().is_final();
     }
 
-    Map<String, MojoExecutionEvent> getValidationTimeEvents() {
+    public Map<String, MojoExecutionEvent> getValidationTimeEvents() {
         return validationTimeEvents;
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
@@ -61,8 +61,7 @@ class ExplicitModuleVersionTest {
 
         // Verify compilation succeeded
         verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
 
         // Second build - should restore from cache
         verifier.setLogFileName("../log-build-2.txt");
@@ -79,7 +78,6 @@ class ExplicitModuleVersionTest {
 
         // Verify output files were restored from cache
         verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for JPMS module compilation with explicit moduleVersion configuration.
+ *
+ * <p>This test verifies that the validation-time property capture approach works correctly
+ * when the moduleVersion is explicitly configured in the POM. Unlike Maven 4's auto-injection
+ * scenario, this configuration is present at validation time, so there's no timing mismatch.
+ * However, validation-time capture should still work correctly.
+ *
+ * <p>This test verifies:
+ * <ol>
+ *   <li>First build creates cache entry with validation-time properties</li>
+ *   <li>Second build restores from cache successfully</li>
+ *   <li>Explicit configuration is captured correctly at validation time</li>
+ * </ol>
+ */
+@IntegrationTest("src/test/projects/explicit-module-version")
+class ExplicitModuleVersionTest {
+
+    /**
+     * Verifies that JPMS module compilation with explicit moduleVersion works with cache restoration.
+     * This tests that validation-time capture works correctly when moduleVersion is explicitly
+     * configured in the POM (no Maven 4 auto-injection needed).
+     *
+     * @param verifier Maven verifier for running builds
+     * @throws VerificationException if verification fails
+     */
+    @Test
+    void testExplicitModuleVersionCacheRestoration(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        // First build - should create cache entry with validation-time properties
+        verifier.setLogFileName("../log-build-1.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify compilation succeeded
+        verifier.verifyFilePresent("target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+
+        // Second build - should restore from cache
+        verifier.setLogFileName("../log-build-2.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify cache was used (not rebuilt)
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.explicit:explicit-module-version from cache");
+
+        // Verify compilation was skipped (restored from cache)
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+
+        // Verify output files were restored from cache
+        verifier.verifyFilePresent("target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ExplicitModuleVersionTest.java
@@ -56,17 +56,18 @@ class ExplicitModuleVersionTest {
         // First build - should create cache entry with validation-time properties
         verifier.setLogFileName("../log-build-1.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify compilation succeeded
         verifier.verifyFilePresent("target/classes/module-info.class");
         verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+        verifier.verifyFilePresent("target/explicit-module-version-1.0.0-SNAPSHOT.jar");
 
         // Second build - should restore from cache
         verifier.setLogFileName("../log-build-2.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify cache was used (not rebuilt)
@@ -76,8 +77,7 @@ class ExplicitModuleVersionTest {
         // Verify compilation was skipped (restored from cache)
         verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
 
-        // Verify output files were restored from cache
-        verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/explicit/ExplicitVersionModule.class");
+        // Verify JAR was restored from cache
+        verifier.verifyFilePresent("target/explicit-module-version-1.0.0-SNAPSHOT.jar");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
@@ -61,18 +61,19 @@ class Maven4JpmsModuleTest {
         // First build - should create cache entry with validation-time properties
         verifier.setLogFileName("../log-build-1.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify compilation succeeded
         verifier.verifyFilePresent("target/classes/module-info.class");
         verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+        verifier.verifyFilePresent("target/maven4-jpms-module-1.0.0-SNAPSHOT.jar");
 
         // Second build - should restore from cache WITHOUT invalidation
         // This is the critical test: validation-time properties should match stored properties
         verifier.setLogFileName("../log-build-2.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify cache was used (not rebuilt) - this proves the fix works!
@@ -82,8 +83,7 @@ class Maven4JpmsModuleTest {
         // Verify compilation was skipped (restored from cache)
         verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
 
-        // Verify output files were restored from cache
-        verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+        // Verify JAR was restored from cache
+        verifier.verifyFilePresent("target/maven4-jpms-module-1.0.0-SNAPSHOT.jar");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for Maven 4 JPMS module compilation with automatic --module-version injection.
+ *
+ * <p>This test verifies that issue #375 is fixed by the validation-time property capture approach.
+ * Maven 4 automatically injects {@code --module-version ${project.version}} into compiler arguments
+ * during execution. Without the fix, this creates a timing mismatch:
+ * <ul>
+ *   <li>First build: Properties captured during execution (WITH injection)</li>
+ *   <li>Second build: Properties captured during validation (WITHOUT injection yet)</li>
+ *   <li>Result: Cache invalidation due to parameter mismatch</li>
+ * </ul>
+ *
+ * <p>The fix captures properties at validation time for ALL builds, ensuring consistent reading
+ * at the same lifecycle point. This test verifies:
+ * <ol>
+ *   <li>First build creates cache entry</li>
+ *   <li>Second build restores from cache (NO cache invalidation)</li>
+ *   <li>NO {@code ignorePattern} configuration required</li>
+ * </ol>
+ */
+@IntegrationTest("src/test/projects/maven4-jpms-module")
+class Maven4JpmsModuleTest {
+
+    /**
+     * Verifies that Maven 4 JPMS module compilation works with cache restoration.
+     * Maven 4 auto-injects {@code --module-version} during compilation, but the
+     * validation-time capture approach ensures this doesn't cause cache invalidation.
+     *
+     * @param verifier Maven verifier for running builds
+     * @throws VerificationException if verification fails
+     */
+    @Test
+    void testMaven4JpmsModuleCacheRestoration(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        // First build - should create cache entry with validation-time properties
+        verifier.setLogFileName("../log-build-1.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify compilation succeeded
+        verifier.verifyFilePresent("target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+
+        // Second build - should restore from cache WITHOUT invalidation
+        // This is the critical test: validation-time properties should match stored properties
+        verifier.setLogFileName("../log-build-2.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify cache was used (not rebuilt) - this proves the fix works!
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.maven4:maven4-jpms-module from cache");
+
+        // Verify compilation was skipped (restored from cache)
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+
+        // Verify output files were restored from cache
+        verifier.verifyFilePresent("target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Maven4JpmsModuleTest.java
@@ -66,8 +66,7 @@ class Maven4JpmsModuleTest {
 
         // Verify compilation succeeded
         verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
 
         // Second build - should restore from cache WITHOUT invalidation
         // This is the critical test: validation-time properties should match stored properties
@@ -85,7 +84,6 @@ class Maven4JpmsModuleTest {
 
         // Verify output files were restored from cache
         verifier.verifyFilePresent("target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/maven4/HelloMaven4.class");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
@@ -59,12 +59,10 @@ class MultiModuleJpmsTest {
 
         // Verify compilation succeeded for module-a (JPMS)
         verifier.verifyFilePresent("module-a/target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
+        verifier.verifyFilePresent("module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
 
         // Verify compilation succeeded for module-b (non-JPMS)
-        verifier.verifyFilePresent(
-                "module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+        verifier.verifyFilePresent("module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
 
         // Second build - should restore all modules from cache
         verifier.setLogFileName("../log-build-2.txt");
@@ -83,11 +81,9 @@ class MultiModuleJpmsTest {
 
         // Verify output files were restored from cache for module-a
         verifier.verifyFilePresent("module-a/target/classes/module-info.class");
-        verifier.verifyFilePresent(
-                "module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
+        verifier.verifyFilePresent("module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
 
         // Verify output files were restored from cache for module-b
-        verifier.verifyFilePresent(
-                "module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+        verifier.verifyFilePresent("module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for multi-module project with JPMS modules using validation-time property capture.
+ *
+ * <p>This test verifies that the validation-time property capture approach works correctly
+ * in multi-module projects where some modules are JPMS modules and some are regular Java modules.
+ * This ensures that validation-time capture scales properly across project structures.
+ *
+ * <p>This test verifies:
+ * <ol>
+ *   <li>First build creates cache entries for all modules</li>
+ *   <li>Second build restores all modules from cache successfully</li>
+ *   <li>Validation-time capture works consistently across multiple modules</li>
+ * </ol>
+ */
+@IntegrationTest("src/test/projects/multi-module-jpms")
+class MultiModuleJpmsTest {
+
+    /**
+     * Verifies that multi-module project with JPMS modules works with cache restoration.
+     * This ensures validation-time capture scales across multiple modules correctly.
+     *
+     * @param verifier Maven verifier for running builds
+     * @throws VerificationException if verification fails
+     */
+    @Test
+    void testMultiModuleJpmsCacheRestoration(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        // First build - should create cache entries for all modules
+        verifier.setLogFileName("../log-build-1.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify compilation succeeded for module-a (JPMS)
+        verifier.verifyFilePresent("module-a/target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
+
+        // Verify compilation succeeded for module-b (non-JPMS)
+        verifier.verifyFilePresent(
+                "module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+
+        // Second build - should restore all modules from cache
+        verifier.setLogFileName("../log-build-2.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify module-a was restored from cache
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.multi:module-a from cache");
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+
+        // Verify module-b was restored from cache
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.multi:module-b from cache");
+
+        // Verify output files were restored from cache for module-a
+        verifier.verifyFilePresent("module-a/target/classes/module-info.class");
+        verifier.verifyFilePresent(
+                "module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
+
+        // Verify output files were restored from cache for module-b
+        verifier.verifyFilePresent(
+                "module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MultiModuleJpmsTest.java
@@ -54,20 +54,20 @@ class MultiModuleJpmsTest {
         // First build - should create cache entries for all modules
         verifier.setLogFileName("../log-build-1.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify compilation succeeded for module-a (JPMS)
         verifier.verifyFilePresent("module-a/target/classes/module-info.class");
-        verifier.verifyFilePresent("module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
+        verifier.verifyFilePresent("module-a/target/module-a-1.0.0-SNAPSHOT.jar");
 
         // Verify compilation succeeded for module-b (non-JPMS)
-        verifier.verifyFilePresent("module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+        verifier.verifyFilePresent("module-b/target/module-b-1.0.0-SNAPSHOT.jar");
 
         // Second build - should restore all modules from cache
         verifier.setLogFileName("../log-build-2.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify module-a was restored from cache
@@ -79,11 +79,8 @@ class MultiModuleJpmsTest {
         verifier.verifyTextInLog(
                 "Found cached build, restoring org.apache.maven.caching.test.multi:module-b from cache");
 
-        // Verify output files were restored from cache for module-a
-        verifier.verifyFilePresent("module-a/target/classes/module-info.class");
-        verifier.verifyFilePresent("module-a/target/classes/org/apache/maven/caching/test/multi/modulea/ModuleA.class");
-
-        // Verify output files were restored from cache for module-b
-        verifier.verifyFilePresent("module-b/target/classes/org/apache/maven/caching/test/multi/moduleb/ModuleB.class");
+        // Verify JARs were restored from cache
+        verifier.verifyFilePresent("module-a/target/module-a-1.0.0-SNAPSHOT.jar");
+        verifier.verifyFilePresent("module-b/target/module-b-1.0.0-SNAPSHOT.jar");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for non-JPMS Java project with validation-time property capture.
+ *
+ * <p>This test verifies that the validation-time property capture approach doesn't introduce
+ * regressions for regular (non-JPMS) Java projects. These projects don't use module-info.java
+ * and don't trigger Maven 4's --module-version auto-injection, so they should work correctly
+ * with validation-time capture.
+ *
+ * <p>This test verifies:
+ * <ol>
+ *   <li>First build creates cache entry for non-JPMS project</li>
+ *   <li>Second build restores from cache successfully</li>
+ *   <li>No regressions introduced for regular Java projects</li>
+ * </ol>
+ */
+@IntegrationTest("src/test/projects/non-jpms-project")
+class NonJpmsProjectTest {
+
+    /**
+     * Verifies that non-JPMS Java project compilation works correctly with cache restoration.
+     * This ensures validation-time capture doesn't introduce regressions for regular Java projects.
+     *
+     * @param verifier Maven verifier for running builds
+     * @throws VerificationException if verification fails
+     */
+    @Test
+    void testNonJpmsProjectCacheRestoration(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        // First build - should create cache entry with validation-time properties
+        verifier.setLogFileName("../log-build-1.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify compilation succeeded
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+
+        // Second build - should restore from cache
+        verifier.setLogFileName("../log-build-2.txt");
+        verifier.executeGoal("clean");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+
+        // Verify cache was used (not rebuilt)
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.nonjpms:non-jpms-project from cache");
+
+        // Verify compilation was skipped (restored from cache)
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+
+        // Verify output files were restored from cache
+        verifier.verifyFilePresent(
+                "target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
@@ -59,8 +59,7 @@ class NonJpmsProjectTest {
         verifier.verifyErrorFreeLog();
 
         // Verify compilation succeeded
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
 
         // Second build - should restore from cache
         verifier.setLogFileName("../log-build-2.txt");
@@ -76,7 +75,6 @@ class NonJpmsProjectTest {
         verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
 
         // Verify output files were restored from cache
-        verifier.verifyFilePresent(
-                "target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/NonJpmsProjectTest.java
@@ -55,16 +55,17 @@ class NonJpmsProjectTest {
         // First build - should create cache entry with validation-time properties
         verifier.setLogFileName("../log-build-1.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify compilation succeeded
         verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+        verifier.verifyFilePresent("target/non-jpms-project-1.0.0-SNAPSHOT.jar");
 
         // Second build - should restore from cache
         verifier.setLogFileName("../log-build-2.txt");
         verifier.executeGoal("clean");
-        verifier.executeGoal("compile");
+        verifier.executeGoal("package");
         verifier.verifyErrorFreeLog();
 
         // Verify cache was used (not rebuilt)
@@ -74,7 +75,7 @@ class NonJpmsProjectTest {
         // Verify compilation was skipped (restored from cache)
         verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
 
-        // Verify output files were restored from cache
-        verifier.verifyFilePresent("target/classes/org/apache/maven/caching/test/nonjpms/RegularJavaClass.class");
+        // Verify JAR was restored from cache
+        verifier.verifyFilePresent("target/non-jpms-project-1.0.0-SNAPSHOT.jar");
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/its/versioning/RemoteParentVersionBumpInvalidatesTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/versioning/RemoteParentVersionBumpInvalidatesTest.java
@@ -76,6 +76,7 @@ class RemoteParentVersionBumpInvalidatesTest {
         corpInstallV1.setAutoclean(false);
         corpInstallV1.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
         corpInstallV1.setLocalRepo(System.getProperty("localRepo"));
+        corpInstallV1.addCliOption("-Dmaven.build.cache.skipCache=true");
         corpInstallV1.setLogFileName("log-corp-v10-install.txt");
         corpInstallV1.executeGoal("install");
         corpInstallV1.verifyErrorFreeLog();
@@ -101,6 +102,7 @@ class RemoteParentVersionBumpInvalidatesTest {
         corpInstallV11.setAutoclean(false);
         corpInstallV11.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
         corpInstallV11.setLocalRepo(System.getProperty("localRepo"));
+        corpInstallV11.addCliOption("-Dmaven.build.cache.skipCache=true");
         corpInstallV11.setLogFileName("log-corp-v11-install.txt");
         corpInstallV11.executeGoal("install");
         corpInstallV11.verifyErrorFreeLog();

--- a/src/test/projects/explicit-module-version/.mvn/extensions.xml
+++ b/src/test/projects/explicit-module-version/.mvn/extensions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <extensions>
   <extension>
     <groupId>org.apache.maven.extensions</groupId>

--- a/src/test/projects/explicit-module-version/.mvn/extensions.xml
+++ b/src/test/projects/explicit-module-version/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>${projectVersion}</version>
+  </extension>
+</extensions>

--- a/src/test/projects/explicit-module-version/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/explicit-module-version/.mvn/maven-build-cache-config.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
   <configuration>
     <enabled>true</enabled>
     <hashAlgorithm>SHA-256</hashAlgorithm>
   </configuration>
-  <executionControl>
-    <reconcile>
-      <plugin artifactId="maven-compiler-plugin">
-        <!-- Validation-time capture handles explicit moduleVersion correctly -->
-        <reconcile propertyName="compilerArgs"/>
-      </plugin>
-    </reconcile>
-  </executionControl>
 </cache>

--- a/src/test/projects/explicit-module-version/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/explicit-module-version/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+  <configuration>
+    <enabled>true</enabled>
+    <hashAlgorithm>SHA-256</hashAlgorithm>
+  </configuration>
+  <executionControl>
+    <reconcile>
+      <plugin artifactId="maven-compiler-plugin">
+        <!-- Validation-time capture handles explicit moduleVersion correctly -->
+        <reconcile propertyName="compilerArgs"/>
+      </plugin>
+    </reconcile>
+  </executionControl>
+</cache>

--- a/src/test/projects/explicit-module-version/pom.xml
+++ b/src/test/projects/explicit-module-version/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.caching.test.explicit</groupId>
+  <artifactId>explicit-module-version</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Explicit Module Version Test</name>
+  <description>Test project for JPMS module with explicit moduleVersion configuration</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <!-- Explicit moduleVersion configuration - present at validation time -->
+          <compilerArgs>
+            <arg>--module-version</arg>
+            <arg>${project.version}</arg>
+            <arg>-parameters</arg>
+            <arg>-g</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/projects/explicit-module-version/pom.xml
+++ b/src/test/projects/explicit-module-version/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/explicit-module-version/pom.xml
+++ b/src/test/projects/explicit-module-version/pom.xml
@@ -44,9 +44,8 @@ under the License.
         <version>3.13.0</version>
         <configuration>
           <!-- Explicit moduleVersion configuration - present at validation time -->
+          <moduleVersion>${project.version}</moduleVersion>
           <compilerArgs>
-            <arg>--module-version</arg>
-            <arg>${project.version}</arg>
             <arg>-parameters</arg>
             <arg>-g</arg>
           </compilerArgs>

--- a/src/test/projects/explicit-module-version/src/main/java/module-info.java
+++ b/src/test/projects/explicit-module-version/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 module org.apache.maven.caching.test.explicit {
     exports org.apache.maven.caching.test.explicit;
 }

--- a/src/test/projects/explicit-module-version/src/main/java/module-info.java
+++ b/src/test/projects/explicit-module-version/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.apache.maven.caching.test.explicit {
+    exports org.apache.maven.caching.test.explicit;
+}

--- a/src/test/projects/explicit-module-version/src/main/java/org/apache/maven/caching/test/explicit/ExplicitVersionModule.java
+++ b/src/test/projects/explicit-module-version/src/main/java/org/apache/maven/caching/test/explicit/ExplicitVersionModule.java
@@ -1,0 +1,7 @@
+package org.apache.maven.caching.test.explicit;
+
+public class ExplicitVersionModule {
+    public String getMessage() {
+        return "Hello from JPMS module with explicit version!";
+    }
+}

--- a/src/test/projects/explicit-module-version/src/main/java/org/apache/maven/caching/test/explicit/ExplicitVersionModule.java
+++ b/src/test/projects/explicit-module-version/src/main/java/org/apache/maven/caching/test/explicit/ExplicitVersionModule.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.caching.test.explicit;
 
 public class ExplicitVersionModule {

--- a/src/test/projects/maven4-jpms-module/.mvn/extensions.xml
+++ b/src/test/projects/maven4-jpms-module/.mvn/extensions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <extensions>
   <extension>
     <groupId>org.apache.maven.extensions</groupId>

--- a/src/test/projects/maven4-jpms-module/.mvn/extensions.xml
+++ b/src/test/projects/maven4-jpms-module/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>${projectVersion}</version>
+  </extension>
+</extensions>

--- a/src/test/projects/maven4-jpms-module/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/maven4-jpms-module/.mvn/maven-build-cache-config.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
   <configuration>
     <enabled>true</enabled>
     <hashAlgorithm>SHA-256</hashAlgorithm>
   </configuration>
-  <executionControl>
-    <reconcile>
-      <plugin artifactId="maven-compiler-plugin">
-        <!-- NO ignorePattern needed! The validation-time capture fix eliminates the timing mismatch -->
-        <reconcile propertyName="compilerArgs"/>
-      </plugin>
-    </reconcile>
-  </executionControl>
 </cache>

--- a/src/test/projects/maven4-jpms-module/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/maven4-jpms-module/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+  <configuration>
+    <enabled>true</enabled>
+    <hashAlgorithm>SHA-256</hashAlgorithm>
+  </configuration>
+  <executionControl>
+    <reconcile>
+      <plugin artifactId="maven-compiler-plugin">
+        <!-- NO ignorePattern needed! The validation-time capture fix eliminates the timing mismatch -->
+        <reconcile propertyName="compilerArgs"/>
+      </plugin>
+    </reconcile>
+  </executionControl>
+</cache>

--- a/src/test/projects/maven4-jpms-module/pom.xml
+++ b/src/test/projects/maven4-jpms-module/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <!-- Maven 4 auto-injects --module-version during compilation -->
+          <!-- Maven 4 auto-injects module-version during compilation -->
           <!-- No explicit moduleVersion configured -->
           <compilerArgs>
             <arg>-parameters</arg>

--- a/src/test/projects/maven4-jpms-module/pom.xml
+++ b/src/test/projects/maven4-jpms-module/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/maven4-jpms-module/pom.xml
+++ b/src/test/projects/maven4-jpms-module/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.caching.test.maven4</groupId>
+  <artifactId>maven4-jpms-module</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <!-- Maven 4 auto-injects --module-version during compilation -->
+          <!-- No explicit moduleVersion configured -->
+          <compilerArgs>
+            <arg>-parameters</arg>
+            <arg>-g</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/projects/maven4-jpms-module/src/main/java/module-info.java
+++ b/src/test/projects/maven4-jpms-module/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 module org.apache.maven.caching.test.maven4 {
     exports org.apache.maven.caching.test.maven4;
 }

--- a/src/test/projects/maven4-jpms-module/src/main/java/module-info.java
+++ b/src/test/projects/maven4-jpms-module/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.apache.maven.caching.test.maven4 {
+    exports org.apache.maven.caching.test.maven4;
+}

--- a/src/test/projects/maven4-jpms-module/src/main/java/org/apache/maven/caching/test/maven4/HelloMaven4.java
+++ b/src/test/projects/maven4-jpms-module/src/main/java/org/apache/maven/caching/test/maven4/HelloMaven4.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.caching.test.maven4;
 
 public class HelloMaven4 {

--- a/src/test/projects/maven4-jpms-module/src/main/java/org/apache/maven/caching/test/maven4/HelloMaven4.java
+++ b/src/test/projects/maven4-jpms-module/src/main/java/org/apache/maven/caching/test/maven4/HelloMaven4.java
@@ -1,0 +1,7 @@
+package org.apache.maven.caching.test.maven4;
+
+public class HelloMaven4 {
+    public String getMessage() {
+        return "Hello from Maven 4 JPMS module!";
+    }
+}

--- a/src/test/projects/multi-module-jpms/.mvn/extensions.xml
+++ b/src/test/projects/multi-module-jpms/.mvn/extensions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <extensions>
   <extension>
     <groupId>org.apache.maven.extensions</groupId>

--- a/src/test/projects/multi-module-jpms/.mvn/extensions.xml
+++ b/src/test/projects/multi-module-jpms/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>${projectVersion}</version>
+  </extension>
+</extensions>

--- a/src/test/projects/multi-module-jpms/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/multi-module-jpms/.mvn/maven-build-cache-config.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
   <configuration>
     <enabled>true</enabled>
     <hashAlgorithm>SHA-256</hashAlgorithm>
   </configuration>
-  <executionControl>
-    <reconcile>
-      <plugin artifactId="maven-compiler-plugin">
-        <!-- Validation-time capture works across multiple modules -->
-        <reconcile propertyName="compilerArgs"/>
-      </plugin>
-    </reconcile>
-  </executionControl>
 </cache>

--- a/src/test/projects/multi-module-jpms/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/multi-module-jpms/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+  <configuration>
+    <enabled>true</enabled>
+    <hashAlgorithm>SHA-256</hashAlgorithm>
+  </configuration>
+  <executionControl>
+    <reconcile>
+      <plugin artifactId="maven-compiler-plugin">
+        <!-- Validation-time capture works across multiple modules -->
+        <reconcile propertyName="compilerArgs"/>
+      </plugin>
+    </reconcile>
+  </executionControl>
+</cache>

--- a/src/test/projects/multi-module-jpms/module-a/pom.xml
+++ b/src/test/projects/multi-module-jpms/module-a/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.caching.test.multi</groupId>
+    <artifactId>multi-module-jpms</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module A (JPMS)</name>
+  <description>JPMS module with Maven 4 auto-injection</description>
+</project>

--- a/src/test/projects/multi-module-jpms/module-a/pom.xml
+++ b/src/test/projects/multi-module-jpms/module-a/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/multi-module-jpms/module-a/src/main/java/module-info.java
+++ b/src/test/projects/multi-module-jpms/module-a/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 module org.apache.maven.caching.test.multi.modulea {
     exports org.apache.maven.caching.test.multi.modulea;
 }

--- a/src/test/projects/multi-module-jpms/module-a/src/main/java/module-info.java
+++ b/src/test/projects/multi-module-jpms/module-a/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.apache.maven.caching.test.multi.modulea {
+    exports org.apache.maven.caching.test.multi.modulea;
+}

--- a/src/test/projects/multi-module-jpms/module-a/src/main/java/org/apache/maven/caching/test/multi/modulea/ModuleA.java
+++ b/src/test/projects/multi-module-jpms/module-a/src/main/java/org/apache/maven/caching/test/multi/modulea/ModuleA.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.caching.test.multi.modulea;
 
 public class ModuleA {

--- a/src/test/projects/multi-module-jpms/module-a/src/main/java/org/apache/maven/caching/test/multi/modulea/ModuleA.java
+++ b/src/test/projects/multi-module-jpms/module-a/src/main/java/org/apache/maven/caching/test/multi/modulea/ModuleA.java
@@ -1,0 +1,7 @@
+package org.apache.maven.caching.test.multi.modulea;
+
+public class ModuleA {
+    public String getMessage() {
+        return "Hello from Module A (JPMS)!";
+    }
+}

--- a/src/test/projects/multi-module-jpms/module-b/pom.xml
+++ b/src/test/projects/multi-module-jpms/module-b/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.caching.test.multi</groupId>
+    <artifactId>multi-module-jpms</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Module B (Non-JPMS)</name>
+  <description>Regular Java module without JPMS</description>
+</project>

--- a/src/test/projects/multi-module-jpms/module-b/pom.xml
+++ b/src/test/projects/multi-module-jpms/module-b/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/multi-module-jpms/module-b/src/main/java/org/apache/maven/caching/test/multi/moduleb/ModuleB.java
+++ b/src/test/projects/multi-module-jpms/module-b/src/main/java/org/apache/maven/caching/test/multi/moduleb/ModuleB.java
@@ -1,0 +1,7 @@
+package org.apache.maven.caching.test.multi.moduleb;
+
+public class ModuleB {
+    public String getMessage() {
+        return "Hello from Module B (non-JPMS)!";
+    }
+}

--- a/src/test/projects/multi-module-jpms/module-b/src/main/java/org/apache/maven/caching/test/multi/moduleb/ModuleB.java
+++ b/src/test/projects/multi-module-jpms/module-b/src/main/java/org/apache/maven/caching/test/multi/moduleb/ModuleB.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.caching.test.multi.moduleb;
 
 public class ModuleB {

--- a/src/test/projects/multi-module-jpms/pom.xml
+++ b/src/test/projects/multi-module-jpms/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.caching.test.multi</groupId>
+  <artifactId>multi-module-jpms</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Multi-Module JPMS Test</name>
+  <description>Test project for multi-module with mixed JPMS and non-JPMS modules</description>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+          <configuration>
+            <compilerArgs>
+              <arg>-parameters</arg>
+              <arg>-g</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/test/projects/multi-module-jpms/pom.xml
+++ b/src/test/projects/multi-module-jpms/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/non-jpms-project/.mvn/extensions.xml
+++ b/src/test/projects/non-jpms-project/.mvn/extensions.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <extensions>
   <extension>
     <groupId>org.apache.maven.extensions</groupId>

--- a/src/test/projects/non-jpms-project/.mvn/extensions.xml
+++ b/src/test/projects/non-jpms-project/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>${projectVersion}</version>
+  </extension>
+</extensions>

--- a/src/test/projects/non-jpms-project/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/non-jpms-project/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+  <configuration>
+    <enabled>true</enabled>
+    <hashAlgorithm>SHA-256</hashAlgorithm>
+  </configuration>
+  <executionControl>
+    <reconcile>
+      <plugin artifactId="maven-compiler-plugin">
+        <!-- Validation-time capture doesn't affect non-JPMS projects -->
+        <reconcile propertyName="compilerArgs"/>
+      </plugin>
+    </reconcile>
+  </executionControl>
+</cache>

--- a/src/test/projects/non-jpms-project/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/non-jpms-project/.mvn/maven-build-cache-config.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
   <configuration>
     <enabled>true</enabled>
     <hashAlgorithm>SHA-256</hashAlgorithm>
   </configuration>
-  <executionControl>
-    <reconcile>
-      <plugin artifactId="maven-compiler-plugin">
-        <!-- Validation-time capture doesn't affect non-JPMS projects -->
-        <reconcile propertyName="compilerArgs"/>
-      </plugin>
-    </reconcile>
-  </executionControl>
 </cache>

--- a/src/test/projects/non-jpms-project/pom.xml
+++ b/src/test/projects/non-jpms-project/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.caching.test.nonjpms</groupId>
+  <artifactId>non-jpms-project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Non-JPMS Project Test</name>
+  <description>Test project for regular Java project without JPMS</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <!-- Regular Java project - no module-info.java, no moduleVersion -->
+          <compilerArgs>
+            <arg>-parameters</arg>
+            <arg>-g</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/projects/non-jpms-project/pom.xml
+++ b/src/test/projects/non-jpms-project/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/projects/non-jpms-project/src/main/java/org/apache/maven/caching/test/nonjpms/RegularJavaClass.java
+++ b/src/test/projects/non-jpms-project/src/main/java/org/apache/maven/caching/test/nonjpms/RegularJavaClass.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.caching.test.nonjpms;
 
 public class RegularJavaClass {

--- a/src/test/projects/non-jpms-project/src/main/java/org/apache/maven/caching/test/nonjpms/RegularJavaClass.java
+++ b/src/test/projects/non-jpms-project/src/main/java/org/apache/maven/caching/test/nonjpms/RegularJavaClass.java
@@ -1,0 +1,7 @@
+package org.apache.maven.caching.test.nonjpms;
+
+public class RegularJavaClass {
+    public String getMessage() {
+        return "Hello from regular Java class!";
+    }
+}


### PR DESCRIPTION
## Problem

Maven 4 automatically injects `--module-version ${project.version}` into compiler arguments **during execution**, but the build cache validates properties **before execution**. This creates a timing mismatch that causes cache invalidation:

- **First build**: No cache exists → properties captured during/after execution (WITH Maven 4 injection)
- **Second build**: Cache exists → properties captured during validation (WITHOUT injection yet) → mismatch → cache invalidated

## Root Cause Analysis

The cache extension currently reads plugin properties at **different lifecycle points** for different builds:

```
First Build Timeline:
  1. findCachedBuild() → no cache found
  2. Mojos execute → Maven 4 injects --module-version
  3. beforeMojoExecution() fires → captures properties WITH injection
  4. save() stores properties from execution events

Second Build Timeline:
  1. findCachedBuild() → cache found
  2. verifyCacheConsistency() → creates mojo via getConfiguredMojo()
  3. Reads properties → WITHOUT injection (too early in lifecycle)
  4. Compares to first build's stored values (WITH injection)
  5. MISMATCH → cache invalidated!
```

The problem: **validation reads BEFORE injection, storage reads AFTER injection**.

## Solution

Capture properties at **validation time** for ALL builds (even when no cache exists). Store ONLY validation-time values in the cache. This ensures both validation and storage read at the same lifecycle point.

### Implementation

1. **Modified `CacheResult`** to store validation-time mojo events
2. **Modified `BuildCacheMojosExecutionStrategy`** to capture properties immediately after `findCachedBuild()`
3. **Modified `save()`** to store ONLY validation-time events (fails with `AssertionError` if missing)

### Key Code Changes

```java
// In BuildCacheMojosExecutionStrategy.execute():
result = cacheController.findCachedBuild(session, project, mojoExecutions, skipCache);

// NEW: Always capture validation-time properties when cache is enabled
if (cacheState == INITIALIZED) {
    Map<String, MojoExecutionEvent> validationTimeEvents =
        captureValidationTimeProperties(session, project, mojoExecutions);
    result = CacheResult.rebuilded(result, validationTimeEvents);
}
```

```java
// In save():
// Validation-time events MUST exist - no fallback to execution-time
if (result.getValidationTimeEvents() == null || result.getValidationTimeEvents().isEmpty()) {
    throw new AssertionError("Validation-time properties not captured - this is a bug");
}
cacheController.save(result, mojoExecutions, result.getValidationTimeEvents());
```

**Note:** Execution-time values are still captured by `MojoParametersListener` for logging/debugging during the build, but are NOT stored in the cache.

### New Timeline (Both Builds)

```
First Build:
  1. findCachedBuild() → no cache
  2. captureValidationTimeProperties() → reads WITHOUT injection
  3. Mojos execute → Maven 4 injects (logged but not stored)
  4. save() stores ONLY validation-time properties → WITHOUT injection

Second Build:
  1. findCachedBuild() → cache found
  2. verifyCacheConsistency() → reads WITHOUT injection
  3. captureValidationTimeProperties() → reads WITHOUT injection
  4. Compares to first build → BOTH without injection → MATCH!
```

### What Gets Stored vs. Logged

| Data | Stored in Cache | Available in Logs |
|------|-----------------|-------------------|
| Validation-time properties (no injection) | ✅ Yes | ✅ Yes |
| Execution-time properties (with injection) | ❌ No | ✅ Yes |

This approach ensures cache consistency while preserving debugging information in build logs.

## Benefits Over PR #391

| Aspect | PR #391 (`ignorePattern`) | This PR (Validation-Time Capture) |
|--------|--------------------------|-----------------------------------|
| **Approach** | Workaround: Filter mismatched values | Fix: Eliminate timing mismatch |
| **Configuration** | Required | None needed |
| **Flexibility** | Pattern must match version format | Format-agnostic |
| **Maintenance** | Patterns need updates | No maintenance |
| **Scope** | Only fixes known patterns | Fixes ALL auto-injected properties |

## Testing

Created comprehensive integration tests:

1. **Maven4JpmsModuleTest** - JPMS module with Maven 4 auto-injection of `--module-version`
2. **ExplicitModuleVersionTest** - JPMS module with explicit `moduleVersion` configuration
3. **NonJpmsProjectTest** - Regular Java project without JPMS (ensures no regression)
4. **MultiModuleJpmsTest** - Multi-module project with mixed JPMS and non-JPMS modules

All tests verify:
- ✅ First build creates cache
- ✅ Second build restores from cache (NO cache invalidation)
- ✅ NO `ignorePattern` configuration required

## Backward Compatibility

- Fully backward compatible
- Existing caches remain valid
- No configuration changes required
- `ignorePattern` still works but is no longer necessary for Maven 4 injection

## Alternative Approaches Considered

1. **Delay validation until execution** ❌ - Would lose early cache-miss detection performance benefit
2. **Pattern-based filtering (PR #391)** ❌ - Treats symptom (value mismatch) instead of root cause (timing mismatch)
3. **Maven core changes** ❌ - Outside our control, would take years to deploy
4. **Store both validation-time and execution-time** ❌ - Unnecessary complexity, doesn't solve the consistency problem
5. **Validation-time capture + storage (this PR)** ✅ - Fixes root cause, no configuration needed, preserves logging for debugging

## Related Issues

- Fixes #375
- Alternative to #391
- Related to Maven 4 JPMS module compilation

## Migration

No migration needed. This change is transparent to users. Existing projects will benefit automatically.
