### PR TITLE
Fix typo: rename rebuilded() to rebuilt()

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -102,7 +102,6 @@ import static org.apache.commons.lang3.StringUtils.split;
 import static org.apache.maven.buildcache.CacheResult.empty;
 import static org.apache.maven.buildcache.CacheResult.failure;
 import static org.apache.maven.buildcache.CacheResult.partialSuccess;
-import static org.apache.maven.buildcache.CacheResult.rebuilt;
 import static org.apache.maven.buildcache.CacheResult.success;
 import static org.apache.maven.buildcache.RemoteCacheRepository.BUILDINFO_XML;
 import static org.apache.maven.buildcache.checksum.KeyUtils.getVersionlessProjectKey;
@@ -529,7 +528,7 @@ public class CacheControllerImpl implements CacheController {
                     hashFactory.getAlgorithm());
             populateGitInfo(build, session);
             build.getDto().set_final(cacheConfig.isSaveToRemoteFinal());
-            cacheResults.put(getVersionlessProjectKey(project), rebuilt(cacheResult, build));
+            cacheResults.put(getVersionlessProjectKey(project), CacheResult.rebuilt(cacheResult, build));
 
             localCache.beforeSave(context);
 

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -70,10 +70,18 @@ public class CacheResult {
         return new CacheResult(RestoreStatus.FAILURE, null, context);
     }
 
-    public static CacheResult rebuilt(CacheResult orig, Build build) {
-        requireNonNull(orig);
+    public static CacheResult rebuilt(CacheResult original, Build build) {
+        requireNonNull(original);
         requireNonNull(build);
-        return new CacheResult(orig.status, build, orig.context);
+        return new CacheResult(original.status, build, original.context);
+    }
+
+    /**
+     * @deprecated Use {@link #rebuilt(CacheResult, Build)} instead.
+     */
+    @Deprecated
+    public static CacheResult rebuilded(CacheResult original, Build build) {
+        return rebuilt(original, build);
     }
 
     public boolean isSuccess() {


### PR DESCRIPTION
## Summary
- Renames `CacheResult.rebuilded()` method to `CacheResult.rebuilt()` for correct English grammar

## Context
This was flagged during review of PR #395 with the comment "not for this PR, but this method name isn't grammatical".