### PR TITLE
set release version to 11 so build works with jdk11

### DIFF
--- a/src/test/projects/issue-393-compile-restore/pom.xml
+++ b/src/test/projects/issue-393-compile-restore/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
 </project>


### PR DESCRIPTION
The build fails with jdk11 with `Fatal error compiling: error: release version 17 not supported` see the build of pull request `Bump org.apache.maven.extensions:maven-extensions from 45 to 46` https://github.com/apache/maven-build-cache-extension/pull/425

The main pom.xml states `<minimalJavaBuildVersion>` is `11` and Jenkins runs jdk11, jdk17 and jdk21. So `<maven.compiler.release>` should be lowerd from `17` to `11`.  The failing test requires Java 9 as minimum because it has a module-info.java