### PR TITLE
Migrate from JSR-305 to JSpecify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@ under the License.
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
       <version>1.0.0</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -194,10 +194,9 @@ under the License.
       <artifactId>plexus-xml</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>compile</scope>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/apache/maven/buildcache/CacheContext.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheContext.java
@@ -21,6 +21,7 @@ package org.apache.maven.buildcache;
 import org.apache.maven.buildcache.xml.build.ProjectsInputInfo;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -39,14 +40,17 @@ public class CacheContext {
         this.session = requireNonNull(session);
     }
 
+    @NonNull
     public MavenProject getProject() {
         return project;
     }
 
+    @NonNull
     public ProjectsInputInfo getInputInfo() {
         return inputInfo;
     }
 
+    @NonNull
     public MavenSession getSession() {
         return session;
     }

--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -94,6 +93,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.aether.RepositorySystem;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,7 +186,7 @@ public class CacheControllerImpl implements CacheController {
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public CacheResult findCachedBuild(
             MavenSession session, MavenProject project, List<MojoExecution> mojoExecutions, boolean skipCache) {
         final LifecyclePhasesHelper lifecyclePhasesHelper = providerLifecyclePhasesHelper.get();

--- a/src/main/java/org/apache/maven/buildcache/CacheRepository.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheRepository.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import java.io.IOException;
 import java.util.Optional;
 
@@ -27,13 +25,14 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.report.CacheReport;
 import org.apache.maven.execution.MavenSession;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Cache repository.
  */
 public interface CacheRepository {
 
-    @Nonnull
+    @NonNull
     Optional<Build> findBuild(CacheContext context) throws IOException;
 
     void saveBuildInfo(CacheResult cacheResult, Build build) throws IOException;

--- a/src/main/java/org/apache/maven/buildcache/CacheResult.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheResult.java
@@ -20,6 +20,8 @@ package org.apache.maven.buildcache;
 
 import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.CacheSource;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +34,7 @@ public class CacheResult {
     private final Build build;
     private final CacheContext context;
 
-    private CacheResult(RestoreStatus status, Build build, CacheContext context) {
+    private CacheResult(RestoreStatus status, @Nullable Build build, @Nullable CacheContext context) {
         this.status = requireNonNull(status);
         this.build = build;
         this.context = context;
@@ -88,14 +90,17 @@ public class CacheResult {
         return status == RestoreStatus.SUCCESS;
     }
 
+    @Nullable
     public Build getBuildInfo() {
         return build;
     }
 
+    @Nullable
     public CacheSource getSource() {
         return build != null ? build.getSource() : null;
     }
 
+    @Nullable
     public CacheContext getContext() {
         return context;
     }
@@ -104,6 +109,7 @@ public class CacheResult {
         return status == RestoreStatus.PARTIAL;
     }
 
+    @NonNull
     public RestoreStatus getStatus() {
         return status;
     }

--- a/src/main/java/org/apache/maven/buildcache/CacheUtils.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheUtils.java
@@ -51,6 +51,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import static org.apache.maven.artifact.Artifact.LATEST_VERSION;
@@ -69,10 +70,11 @@ public class CacheUtils {
         return dependency.getType().equals("pom");
     }
 
-    public static boolean isSnapshot(String version) {
+    public static boolean isSnapshot(@Nullable String version) {
         return version != null && (version.endsWith(SNAPSHOT_VERSION) || version.endsWith(LATEST_VERSION));
     }
 
+    @Nullable
     public static String normalizedName(Artifact artifact) {
         if (artifact.getFile() == null) {
             return null;
@@ -241,7 +243,7 @@ public class CacheUtils {
     }
 
     public static <T> void debugPrintCollection(
-            Logger logger, Collection<T> values, String heading, String elementCaption) {
+            Logger logger, @Nullable Collection<T> values, @Nullable String heading, @Nullable String elementCaption) {
         if (logger.isDebugEnabled() && values != null && !values.isEmpty()) {
             final int size = values.size();
             int i = 0;

--- a/src/main/java/org/apache/maven/buildcache/DefaultPluginScanConfig.java
+++ b/src/main/java/org/apache/maven/buildcache/DefaultPluginScanConfig.java
@@ -18,9 +18,8 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import org.apache.maven.buildcache.xml.config.DirScanConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * DefaultPluginScanConfig
@@ -38,12 +37,12 @@ public class DefaultPluginScanConfig implements PluginScanConfig {
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public PluginScanConfig mergeWith(PluginScanConfig overrideSource) {
         return overrideSource;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public ScanConfigProperties getTagScanProperties(String tagName) {
         return new ScanConfigProperties(true, "*");

--- a/src/main/java/org/apache/maven/buildcache/LifecyclePhasesHelper.java
+++ b/src/main/java/org/apache/maven/buildcache/LifecyclePhasesHelper.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -40,6 +39,7 @@ import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +103,7 @@ public class LifecyclePhasesHelper extends AbstractExecutionListener {
         forkedProjectToOrigin.remove(event.getProject(), event.getMojoExecution());
     }
 
-    @Nonnull
+    @NonNull
     public String resolveHighestLifecyclePhase(MavenProject project, List<MojoExecution> mojoExecutions) {
         return resolveMojoExecutionLifecyclePhase(project, CacheUtils.getLast(mojoExecutions));
     }

--- a/src/main/java/org/apache/maven/buildcache/LocalCacheRepository.java
+++ b/src/main/java/org/apache/maven/buildcache/LocalCacheRepository.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -29,6 +27,7 @@ import org.apache.maven.buildcache.xml.CacheSource;
 import org.apache.maven.buildcache.xml.build.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Local cache repository.
@@ -41,9 +40,9 @@ public interface LocalCacheRepository extends CacheRepository {
 
     void clearCache(CacheContext context);
 
-    @Nonnull
+    @NonNull
     Optional<Build> findBestMatchingBuild(MavenSession session, Dependency dependency) throws IOException;
 
-    @Nonnull
+    @NonNull
     Optional<Build> findLocalBuild(CacheContext context) throws IOException;
 }

--- a/src/main/java/org/apache/maven/buildcache/LocalCacheRepositoryImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/LocalCacheRepositoryImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -57,6 +56,7 @@ import org.apache.maven.buildcache.xml.report.CacheReport;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +100,7 @@ public class LocalCacheRepositoryImpl implements LocalCacheRepository {
         this.cacheConfig = cacheConfig;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findLocalBuild(CacheContext context) throws IOException {
         Path localBuildInfoPath = localBuildPath(context, BUILDINFO_XML, false);
@@ -119,7 +119,7 @@ public class LocalCacheRepositoryImpl implements LocalCacheRepository {
         return Optional.empty();
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBuild(CacheContext context) throws IOException {
         Path buildInfoPath = remoteBuildPath(context, BUILDINFO_XML);
@@ -218,13 +218,13 @@ public class LocalCacheRepositoryImpl implements LocalCacheRepository {
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBestMatchingBuild(MavenSession session, Dependency dependency) {
         return bestBuildCache.computeIfAbsent(Pair.of(session, dependency), this::findBestMatchingBuildImpl);
     }
 
-    @Nonnull
+    @NonNull
     private Optional<Build> findBestMatchingBuildImpl(Pair<MavenSession, Dependency> dependencySession) {
         try {
             final MavenSession session = dependencySession.getLeft();

--- a/src/main/java/org/apache/maven/buildcache/PluginScanConfig.java
+++ b/src/main/java/org/apache/maven/buildcache/PluginScanConfig.java
@@ -18,9 +18,8 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import org.apache.maven.buildcache.xml.config.DirScanConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * PluginScanConfig
@@ -33,7 +32,7 @@ public interface PluginScanConfig {
 
     PluginScanConfig mergeWith(PluginScanConfig overrideSource);
 
-    @Nonnull
+    @NonNull
     ScanConfigProperties getTagScanProperties(String tagName);
 
     DirScanConfig dto();

--- a/src/main/java/org/apache/maven/buildcache/PluginScanConfig.java
+++ b/src/main/java/org/apache/maven/buildcache/PluginScanConfig.java
@@ -20,6 +20,7 @@ package org.apache.maven.buildcache;
 
 import org.apache.maven.buildcache.xml.config.DirScanConfig;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * PluginScanConfig
@@ -35,5 +36,6 @@ public interface PluginScanConfig {
     @NonNull
     ScanConfigProperties getTagScanProperties(String tagName);
 
+    @Nullable
     DirScanConfig dto();
 }

--- a/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
@@ -18,14 +18,13 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 
 import org.apache.commons.lang3.Strings;
 import org.apache.maven.buildcache.xml.config.DirScanConfig;
 import org.apache.maven.buildcache.xml.config.TagExclude;
 import org.apache.maven.buildcache.xml.config.TagScanConfig;
+import org.jspecify.annotations.NonNull;
 
 /**
  * PluginScanConfigImpl
@@ -65,7 +64,7 @@ public class PluginScanConfigImpl implements PluginScanConfig {
         return false;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public PluginScanConfig mergeWith(final PluginScanConfig overrideConfig) {
         if (dto == null) {
@@ -97,7 +96,7 @@ public class PluginScanConfigImpl implements PluginScanConfig {
         return new PluginScanConfigImpl(merged);
     }
 
-    @Nonnull
+    @NonNull
     public ScanConfigProperties getTagScanProperties(String tagName) {
         ScanConfigProperties scanProperties = findTagScanProperties(tagName);
         return scanProperties != null ? scanProperties : defaultScanConfig();

--- a/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
@@ -25,6 +25,7 @@ import org.apache.maven.buildcache.xml.config.DirScanConfig;
 import org.apache.maven.buildcache.xml.config.TagExclude;
 import org.apache.maven.buildcache.xml.config.TagScanConfig;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * PluginScanConfigImpl
@@ -33,7 +34,7 @@ public class PluginScanConfigImpl implements PluginScanConfig {
 
     private final DirScanConfig dto;
 
-    public PluginScanConfigImpl(DirScanConfig scanConfig) {
+    public PluginScanConfigImpl(@Nullable DirScanConfig scanConfig) {
         this.dto = scanConfig;
     }
 
@@ -102,11 +103,13 @@ public class PluginScanConfigImpl implements PluginScanConfig {
         return scanProperties != null ? scanProperties : defaultScanConfig();
     }
 
+    @Nullable
     @Override
     public DirScanConfig dto() {
         return dto;
     }
 
+    @Nullable
     private ScanConfigProperties findTagScanProperties(String tagName) {
         ScanConfigProperties scanConfigProperties = findConfigByName(tagName, dto.getIncludes());
         if (scanConfigProperties == null) {
@@ -115,6 +118,7 @@ public class PluginScanConfigImpl implements PluginScanConfig {
         return scanConfigProperties;
     }
 
+    @Nullable
     private ScanConfigProperties findConfigByName(String tagName, List<TagScanConfig> configs) {
         if (configs == null) {
             return null;

--- a/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/PluginScanConfigImpl.java
@@ -40,11 +40,14 @@ public class PluginScanConfigImpl implements PluginScanConfig {
 
     @Override
     public boolean isSkip() {
-        return Strings.CS.equals(dto.getMode(), "skip");
+        return dto != null && Strings.CS.equals(dto.getMode(), "skip");
     }
 
     @Override
     public boolean accept(String tagName) {
+        if (dto == null) {
+            return false;
+        }
         // include or exclude is a choice element, could be only obe property set
 
         //noinspection ConstantConditions

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepository.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepository.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -27,6 +25,7 @@ import java.util.Optional;
 import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.build.Artifact;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Remote cache repository.
@@ -43,9 +42,9 @@ public interface RemoteCacheRepository extends CacheRepository {
      */
     boolean getArtifactContent(CacheContext context, Artifact artifact, Path target) throws IOException;
 
-    @Nonnull
+    @NonNull
     String getResourceUrl(CacheContext context, String filename);
 
-    @Nonnull
+    @NonNull
     Optional<Build> findBaselineBuild(MavenProject project);
 }

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepository.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepository.java
@@ -26,6 +26,7 @@ import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.build.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Remote cache repository.
@@ -42,7 +43,7 @@ public interface RemoteCacheRepository extends CacheRepository {
      */
     boolean getArtifactContent(CacheContext context, Artifact artifact, Path target) throws IOException;
 
-    @NonNull
+    @Nullable
     String getResourceUrl(CacheContext context, String filename);
 
     @NonNull

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
@@ -55,6 +55,7 @@ import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.aether.spi.connector.transport.TransporterProvider;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,7 +149,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
      * @return null or content
      */
     @NonNull
-    public Optional<byte[]> getResourceContent(String url) {
+    public Optional<byte[]> getResourceContent(@Nullable String url) {
         String fullUrl = getFullUrl(url);
         try {
             LOGGER.info("Downloading {}", fullUrl);
@@ -201,7 +202,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    public boolean getResourceContent(String url, Path target) {
+    public boolean getResourceContent(@Nullable String url, Path target) {
         try {
             LOGGER.info("Downloading {}", getFullUrl(url));
             GetTask task = new GetTask(new URI(url)).setDataFile(target.toFile());
@@ -213,7 +214,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    @NonNull
+    @Nullable
     @Override
     public String getResourceUrl(CacheContext context, String filename) {
         return getResourceUrl(
@@ -228,7 +229,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
                 + filename;
     }
 
-    private void putToRemoteCache(byte[] bytes, String url) throws IOException {
+    private void putToRemoteCache(byte[] bytes, @Nullable String url) throws IOException {
         Path tmp = Files.createTempFile("mbce-", ".tmp");
         try {
             Files.write(tmp, bytes);
@@ -243,7 +244,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    private void putToRemoteCache(File file, String url) throws IOException {
+    private void putToRemoteCache(File file, @Nullable String url) throws IOException {
         try {
             PutTask put = new PutTask(new URI(url));
             put.setDataFile(file);
@@ -313,7 +314,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         return report;
     }
 
-    private String getFullUrl(String url) {
+    private String getFullUrl(@Nullable String url) {
         return cacheConfig.getUrl() + "/" + url;
     }
 }

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -55,6 +54,7 @@ import org.eclipse.aether.spi.connector.transport.GetTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.aether.spi.connector.transport.TransporterProvider;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +105,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBuild(CacheContext context) throws IOException {
         final String resourceUrl = getResourceUrl(context, BUILDINFO_XML);
@@ -147,7 +147,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
      *
      * @return null or content
      */
-    @Nonnull
+    @NonNull
     public Optional<byte[]> getResourceContent(String url) {
         String fullUrl = getFullUrl(url);
         try {
@@ -213,7 +213,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public String getResourceUrl(CacheContext context, String filename) {
         return getResourceUrl(
@@ -256,7 +256,7 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
 
     private final AtomicReference<CacheReport> cacheReportSupplier = new AtomicReference<>();
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBaselineBuild(MavenProject project) {
         Optional<List<ProjectReport>> cachedProjectsHolder = findCacheInfo().map(CacheReport::getProjects);

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryNoOp.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryNoOp.java
@@ -31,6 +31,7 @@ import org.apache.maven.buildcache.xml.report.CacheReport;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @SessionScoped
 @Named("noop")
@@ -58,6 +59,7 @@ public class RemoteCacheRepositoryNoOp implements RemoteCacheRepository {
         return false;
     }
 
+    @Nullable
     @Override
     public String getResourceUrl(CacheContext context, String filename) {
         return null;

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryNoOp.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryNoOp.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.buildcache;
 
-import javax.annotation.Nonnull;
 import javax.inject.Named;
 
 import java.io.IOException;
@@ -31,12 +30,13 @@ import org.apache.maven.buildcache.xml.Build;
 import org.apache.maven.buildcache.xml.report.CacheReport;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
 
 @SessionScoped
 @Named("noop")
 public class RemoteCacheRepositoryNoOp implements RemoteCacheRepository {
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBuild(CacheContext context) throws IOException {
         return Optional.empty();
@@ -63,7 +63,7 @@ public class RemoteCacheRepositoryNoOp implements RemoteCacheRepository {
         return null;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Optional<Build> findBaselineBuild(MavenProject project) {
         return Optional.empty();

--- a/src/main/java/org/apache/maven/buildcache/ScanConfigProperties.java
+++ b/src/main/java/org/apache/maven/buildcache/ScanConfigProperties.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.buildcache;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * ScanConfigProperties
  */
@@ -26,7 +28,7 @@ public class ScanConfigProperties {
     private final boolean recursive;
     private final String glob;
 
-    public ScanConfigProperties(boolean recursive, String glob) {
+    public ScanConfigProperties(boolean recursive, @Nullable String glob) {
         this.recursive = recursive;
         this.glob = glob;
     }
@@ -35,6 +37,7 @@ public class ScanConfigProperties {
         return recursive;
     }
 
+    @Nullable
     public String getGlob() {
         return glob;
     }

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache.checksum;
 
-import javax.annotation.Nonnull;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -90,6 +88,7 @@ import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -819,7 +818,7 @@ public class MavenProjectInput {
         return result;
     }
 
-    @Nonnull
+    @NonNull
     private DigestItem resolveArtifact(final Dependency dependency)
             throws IOException, ArtifactResolutionException, InvalidVersionSpecificationException {
 

--- a/src/main/java/org/apache/maven/buildcache/checksum/WalkKey.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/WalkKey.java
@@ -20,6 +20,8 @@ package org.apache.maven.buildcache.checksum;
 
 import java.nio.file.Path;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * WalkKey
  */
@@ -36,7 +38,7 @@ public class WalkKey {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfig.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfig.java
@@ -85,6 +85,7 @@ public interface CacheConfig {
 
     String getId();
 
+    @Nullable
     String getUrl();
 
     String getTransport();
@@ -103,6 +104,7 @@ public interface CacheConfig {
 
     int getMaxLocalBuildsCached();
 
+    @Nullable
     String getLocalRepositoryLocation();
 
     List<DirName> getAttachedOutputs();
@@ -120,6 +122,7 @@ public interface CacheConfig {
 
     boolean isBaselineDiffEnabled();
 
+    @Nullable
     String getBaselineCacheUrl();
 
     /**
@@ -142,6 +145,7 @@ public interface CacheConfig {
      */
     boolean isRestoreOnDiskArtifacts();
 
+    @Nullable
     String getAlwaysRunPlugins();
 
     /**

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfig.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfig.java
@@ -18,9 +18,6 @@
  */
 package org.apache.maven.buildcache.xml;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -35,27 +32,29 @@ import org.apache.maven.buildcache.xml.config.TrackedProperty;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A java interface to the information configured in the maven-build-cache-config.xml file
  */
 public interface CacheConfig {
 
-    @Nonnull
+    @NonNull
     CacheState initialize();
 
-    @Nonnull
+    @NonNull
     List<TrackedProperty> getTrackedProperties(MojoExecution mojoExecution);
 
     boolean isLogAllProperties(MojoExecution mojoExecution);
 
-    @Nonnull
+    @NonNull
     List<PropertyName> getLoggedProperties(MojoExecution mojoExecution);
 
-    @Nonnull
+    @NonNull
     List<PropertyName> getNologProperties(MojoExecution mojoExecution);
 
-    @Nonnull
+    @NonNull
     List<String> getEffectivePomExcludeProperties(Plugin plugin);
 
     boolean isPluginDependenciesExcluded(Plugin plugin);
@@ -67,19 +66,19 @@ public interface CacheConfig {
 
     String getDefaultGlob();
 
-    @Nonnull
+    @NonNull
     List<Include> getGlobalIncludePaths();
 
-    @Nonnull
+    @NonNull
     List<Exclude> getGlobalExcludePaths();
 
-    @Nonnull
+    @NonNull
     PluginScanConfig getPluginDirScanConfig(Plugin plugin);
 
-    @Nonnull
+    @NonNull
     PluginScanConfig getExecutionDirScanConfig(Plugin plugin, PluginExecution exec);
 
-    @Nonnull
+    @NonNull
     HashFactory getHashFactory();
 
     boolean isForcedExecution(MojoExecution execution);
@@ -116,7 +115,7 @@ public interface CacheConfig {
 
     boolean canIgnore(MojoExecution mojoExecution);
 
-    @Nonnull
+    @NonNull
     List<Pattern> getExcludePatterns();
 
     boolean isBaselineDiffEnabled();

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
@@ -248,6 +248,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
                 && cacheConfig.getExecutionControl().getReconcile().isLogAllProperties();
     }
 
+    @Nullable
     private GoalReconciliation findReconciliationConfig(MojoExecution mojoExecution) {
         if (cacheConfig.getExecutionControl() == null) {
             return null;
@@ -327,6 +328,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return cacheConfig.getConfiguration().getMultiModule();
     }
 
+    @Nullable
     private PluginConfigurationScan findPluginScanConfig(Plugin plugin) {
         if (cacheConfig.getInput() == null) {
             return null;
@@ -377,6 +379,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return new DefaultPluginScanConfig();
     }
 
+    @Nullable
     private ExecutionConfigurationScan findExecutionScanConfig(
             PluginExecution execution, List<ExecutionConfigurationScan> scanConfigs) {
         for (ExecutionConfigurationScan executionScanConfig : scanConfigs) {
@@ -507,6 +510,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return getProperty(BASELINE_BUILD_URL_PROPERTY_NAME, null) != null;
     }
 
+    @Nullable
     @Override
     public String getBaselineCacheUrl() {
         return getProperty(BASELINE_BUILD_URL_PROPERTY_NAME, null);
@@ -527,6 +531,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return getProperty(RESTORE_ON_DISK_ARTIFACTS_PROPERTY_NAME, true);
     }
 
+    @Nullable
     @Override
     public String getAlwaysRunPlugins() {
         return getProperty(ALWAYS_RUN_PLUGINS, null);
@@ -553,6 +558,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return getProperty(REMOTE_SERVER_ID_PROPERTY_NAME, getRemote().getId());
     }
 
+    @Nullable
     @Override
     public String getUrl() {
         checkInitializedState();
@@ -571,6 +577,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return getLocal().getMaxBuildsCached();
     }
 
+    @Nullable
     @Override
     public String getLocalRepositoryLocation() {
         checkInitializedState();
@@ -649,7 +656,8 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         }
     }
 
-    private String getProperty(String key, String defaultValue) {
+    @Nullable
+    private String getProperty(String key, @Nullable String defaultValue) {
         MavenSession session = providerSession.get();
         String value = session.getUserProperties().getProperty(key);
         if (value == null) {

--- a/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/CacheConfigImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache.xml;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -68,6 +66,8 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.rtinfo.RuntimeInformation;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,7 +132,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         this.rtInfo = rtInfo;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public CacheState initialize() {
         if (state == null) {
@@ -225,7 +225,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<TrackedProperty> getTrackedProperties(MojoExecution mojoExecution) {
         checkInitializedState();
@@ -272,7 +272,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return null;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<PropertyName> getLoggedProperties(MojoExecution mojoExecution) {
         checkInitializedState();
@@ -285,7 +285,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<PropertyName> getNologProperties(MojoExecution mojoExecution) {
         checkInitializedState();
@@ -297,7 +297,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<String> getEffectivePomExcludeProperties(Plugin plugin) {
         checkInitializedState();
@@ -348,7 +348,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
                         || Strings.CS.equals(pluginConfig.getGroupId(), plugin.getGroupId()));
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public PluginScanConfig getPluginDirScanConfig(Plugin plugin) {
         checkInitializedState();
@@ -360,7 +360,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return new PluginScanConfigImpl(pluginConfig.getDirScan());
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public PluginScanConfig getExecutionDirScanConfig(Plugin plugin, PluginExecution exec) {
         checkInitializedState();
@@ -399,21 +399,21 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         return StringUtils.trim(cacheConfig.getInput().getGlobal().getGlob());
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<Include> getGlobalIncludePaths() {
         checkInitializedState();
         return cacheConfig.getInput().getGlobal().getIncludes();
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<Exclude> getGlobalExcludePaths() {
         checkInitializedState();
         return cacheConfig.getInput().getGlobal().getExcludes();
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public HashFactory getHashFactory() {
         checkInitializedState();
@@ -613,7 +613,7 @@ public class CacheConfigImpl implements org.apache.maven.buildcache.xml.CacheCon
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public List<Pattern> getExcludePatterns() {
         checkInitializedState();

--- a/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
@@ -30,6 +30,7 @@ import org.apache.maven.buildcache.xml.build.PropertyValue;
 import org.apache.maven.buildcache.xml.config.TrackedProperty;
 import org.apache.maven.model.Dependency;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +109,7 @@ public class DtoUtils {
     }
 
     public static void addProperty(
-            CompletedExecution execution, String propertyName, Object value, String baseDirPath, boolean tracked) {
+            CompletedExecution execution, String propertyName, @Nullable Object value, String baseDirPath, boolean tracked) {
         final PropertyValue valueType = new PropertyValue();
         valueType.setName(propertyName);
         if (value != null && value.getClass().isArray()) {
@@ -128,7 +129,7 @@ public class DtoUtils {
      * @return                   true if all tracked properties are listed in the cache record
      */
     public static boolean containsAllProperties(
-            @NonNull CompletedExecution cachedExecution, List<TrackedProperty> trackedProperties) {
+            @NonNull CompletedExecution cachedExecution, @Nullable List<TrackedProperty> trackedProperties) {
         if (trackedProperties == null || trackedProperties.isEmpty()) {
             return true;
         }

--- a/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
@@ -109,7 +109,11 @@ public class DtoUtils {
     }
 
     public static void addProperty(
-            CompletedExecution execution, String propertyName, @Nullable Object value, String baseDirPath, boolean tracked) {
+            CompletedExecution execution,
+            String propertyName,
+            @Nullable Object value,
+            String baseDirPath,
+            boolean tracked) {
         final PropertyValue valueType = new PropertyValue();
         valueType.setName(propertyName);
         if (value != null && value.getClass().isArray()) {

--- a/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/DtoUtils.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.buildcache.xml;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -31,6 +29,7 @@ import org.apache.maven.buildcache.xml.build.DigestItem;
 import org.apache.maven.buildcache.xml.build.PropertyValue;
 import org.apache.maven.buildcache.xml.config.TrackedProperty;
 import org.apache.maven.model.Dependency;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +128,7 @@ public class DtoUtils {
      * @return                   true if all tracked properties are listed in the cache record
      */
     public static boolean containsAllProperties(
-            @Nonnull CompletedExecution cachedExecution, List<TrackedProperty> trackedProperties) {
+            @NonNull CompletedExecution cachedExecution, List<TrackedProperty> trackedProperties) {
         if (trackedProperties == null || trackedProperties.isEmpty()) {
             return true;
         }

--- a/src/test/java/org/apache/maven/buildcache/util/LogFileUtils.java
+++ b/src/test/java/org/apache/maven/buildcache/util/LogFileUtils.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utils to inspect the generated log file
@@ -42,6 +43,7 @@ public final class LogFileUtils {
      * @return the first matching string or null
      * @throws VerificationException
      */
+    @Nullable
     public static String findFirstLineContainingTextsInLogs(final Verifier verifier, final String... texts)
             throws VerificationException {
         List<String> lines = verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false);


### PR DESCRIPTION
Migrate from JSR-305 tot JSpecify

Maven Build Cache Extension depends on JSR-250: Common Annotations for the Java Platform (javax.annotation) which exports the `javax.annotation` package. The JSR-305: Annotations for Software Defect Detection (jsr305) part of Google Findbugs also exports the `javax.annotation` package. With JPMS it's not possible to compile having both dependencies.

[JSpecify ](https://jspecify.dev/) standerdizes the `@Nullable` and `@NonNull` annotations.

### Changes
- Replaced the dependency jsr305 with jspecify
- Replaced the `@javax.annotation.Nonnull` and `@javax.annotation.Nullable` annotation to the `@org.jspecify.annotations.NonNull` and `@org.jspecify.annotations.Nullable` annotations
- Added `@Nullable` to return values and parameters which could be null
- Added checks to `PluginScanConfigImpl` `isSkip()` and `accept(tagName)` to prevent NullPointenException when dto is null
- Added `@NonNull` to return values of `CacheContext` and `CacheResult` for values set with `requireNonNull(value)`
- Changed `@NonNull` to `@Nullable` in `RemoteCacheRepository` `getResourceUrl(context, filename)` because implementation `RemoteCacheRepositoryNoOp` returned `null` so it's nullable

### Further improvement
When Maven Build Cache Extesion changes `<javaVersion>8</javaVersion>` in the pom.xml to Java 9+. Then it would become possible to remove all `@NonNull` annotations and annotate the packages with `@NullMarked`. Because `@NullMarked` targets `MODULE` which has been added in Java 9 so `MODULE` is not compatible with Java 8. With `@NullMarked` every return value and parameter is considered `@NonNull` unless annotated with `@Nullable`. This reduces the amount of annotations needed. 