### PR TITLE
Replace deprecated Plexus WriterFactory usage in MavenProjectInput

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -84,7 +85,6 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.WriterFactory;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -342,7 +342,7 @@ public class MavenProjectInput {
     private String getEffectivePom(Model prototype) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        try (Writer writer = WriterFactory.newXmlWriter(output)) {
+        try (Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8)) {
             new MavenXpp3Writer().write(writer, prototype);
 
             // normalize env specifics

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -336,7 +336,7 @@ public class MavenProjectInput {
      */
     private String getEffectivePom(Model prototype) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        new DefaultModelWriter().write(output, null, prototype);
+        new DefaultModelWriter().write(output, Collections.emptyMap(), prototype);
 
         // normalize env specifics
         final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -341,7 +341,8 @@ public class MavenProjectInput {
         // normalize env specifics
         final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};
         final String[] replacementList = {"", "/", "os.classifier", "os.classifier"};
-        return replaceEachRepeatedly(output.toString(), searchList, replacementList);
+        return replaceEachRepeatedly(
+                output.toString(java.nio.charset.StandardCharsets.UTF_8.name()), searchList, replacementList);
     }
 
     private SortedSet<Path> getInputFiles() {

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -341,8 +341,13 @@ public class MavenProjectInput {
         // normalize env specifics
         final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};
         final String[] replacementList = {"", "/", "os.classifier", "os.classifier"};
-        return replaceEachRepeatedly(
-                output.toString(java.nio.charset.StandardCharsets.UTF_8.name()), searchList, replacementList);
+
+        //Normalize output to ensure consistent encoding, line ending, and whitespace
+        String result = output.toString(java.nio.charset.StandardCharsets.UTF_8.name());
+        result = result.replace("\r\n", "\n");
+        result = result.trim();
+
+        return replaceEachRepeatedly(result, searchList, replacementList);
     }
 
     private SortedSet<Path> getInputFiles() {

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -23,9 +23,6 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -83,7 +80,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
-import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.model.io.DefaultModelWriter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifactType;
@@ -216,8 +213,6 @@ public class MavenProjectInput {
             projectVersion.setIsText("yes");
             projectVersion.setValue(project.getVersion());
             items.add(projectVersion);
-
-            checksum.update(project.getVersion().getBytes(StandardCharsets.UTF_8));
         }
 
         DigestItem effectivePomChecksum = DigestUtils.pom(checksum, effectivePom);
@@ -341,15 +336,12 @@ public class MavenProjectInput {
      */
     private String getEffectivePom(Model prototype) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new DefaultModelWriter().write(output, null, prototype);
 
-        try (Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8)) {
-            new MavenXpp3Writer().write(writer, prototype);
-
-            // normalize env specifics
-            final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};
-            final String[] replacementList = {"", "/", "os.classifier", "os.classifier"};
-            return replaceEachRepeatedly(output.toString(), searchList, replacementList);
-        }
+        // normalize env specifics
+        final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};
+        final String[] replacementList = {"", "/", "os.classifier", "os.classifier"};
+        return replaceEachRepeatedly(output.toString(), searchList, replacementList);
     }
 
     private SortedSet<Path> getInputFiles() {

--- a/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
+++ b/src/main/java/org/apache/maven/buildcache/checksum/MavenProjectInput.java
@@ -23,6 +23,9 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -80,7 +83,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
-import org.apache.maven.model.io.DefaultModelWriter;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifactType;
@@ -213,6 +216,8 @@ public class MavenProjectInput {
             projectVersion.setIsText("yes");
             projectVersion.setValue(project.getVersion());
             items.add(projectVersion);
+
+            checksum.update(project.getVersion().getBytes(StandardCharsets.UTF_8));
         }
 
         DigestItem effectivePomChecksum = DigestUtils.pom(checksum, effectivePom);
@@ -336,14 +341,15 @@ public class MavenProjectInput {
      */
     private String getEffectivePom(Model prototype) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        new DefaultModelWriter().write(output, Collections.emptyMap(), prototype);
+        try (Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8)) {
+            new MavenXpp3Writer().write(output, prototype);
+        }
 
         // normalize env specifics
         final String[] searchList = {baseDirPath.toString(), "\\", "windows", "linux"};
         final String[] replacementList = {"", "/", "os.classifier", "os.classifier"};
 
-        //Normalize output to ensure consistent encoding, line ending, and whitespace
-        String result = output.toString(java.nio.charset.StandardCharsets.UTF_8.name());
+        String result = output.toString(StandardCharsets.UTF_8.name());
         result = result.replace("\r\n", "\n");
         result = result.trim();
 


### PR DESCRIPTION
This PR addresses one of the deprecations reported in #436 by replacing the deprecated plexus-utils `WriterFactory.newXmlWriter(...)` usage in `MavenProjectInput` with an equivalent JDK-based writer.

The change is intentionally small and self-contained, and does not alter behavior.


Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
