### PR TITLE
Only set the project artifact if it is the actual JAR

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -412,12 +412,14 @@ public class CacheControllerImpl implements CacheController {
 
         try {
             RestoredArtifact restoredProjectArtifact = null;
+            boolean restoredProjectArtifactIsDirectory = false;
             List<RestoredArtifact> restoredAttachedArtifacts = new ArrayList<>();
 
             if (build.getArtifact() != null && isNotBlank(build.getArtifact().getFileName())) {
                 final Artifact artifactInfo = build.getArtifact();
                 String originalVersion = artifactInfo.getVersion();
                 artifactInfo.setVersion(project.getVersion());
+                restoredProjectArtifactIsDirectory = artifactInfo.isIsDirectory();
                 // TODO if remote is forced, probably need to refresh or reconcile all files
                 final Future<File> downloadTask =
                         createDownloadTask(cacheResult, context, project, artifactInfo, originalVersion);
@@ -470,7 +472,10 @@ public class CacheControllerImpl implements CacheController {
             }
             // Actually modify project at the end in case something went wrong during restoration,
             // in which case, the project is unmodified and we continue with normal build.
-            if (restoredProjectArtifact != null) {
+            //
+            // Also, only restore the project artifact, if it was an actually fully build JAR,
+            // and not the cached compile results.
+            if (restoredProjectArtifact != null && !restoredProjectArtifactIsDirectory) {
                 project.setArtifact(restoredProjectArtifact);
                 // need to include package lifecycle to save build info for incremental builds
                 if (!project.hasLifecyclePhase("package")) {

--- a/src/test/java/org/apache/maven/buildcache/its/Issue449Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue449Test.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@IntegrationTest("src/test/projects/issue-449-artifact-restore")
+class Issue449Test {
+
+    @Test
+    void installAfterCleanCompileShouldWork(Verifier verifier) throws VerificationException {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
+        verifier.setAutoclean(false);
+
+        verifier.setLogFileName("../log-0.txt");
+        verifier.executeGoals(asList("clean", "compile"));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Saved Build to local file");
+        verifier.verifyTextInLog("Local build was not found");
+
+        verifier.setLogFileName("../log-1.txt");
+        verifier.executeGoals(asList("clean", "install"));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Found cached build, restoring");
+        verifier.verifyTextInLog("Saved Build to local file");
+    }
+}

--- a/src/test/java/org/apache/maven/buildcache/its/Issue449Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue449Test.java
@@ -18,22 +18,21 @@
  */
 package org.apache.maven.buildcache.its;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.buildcache.its.junit.IntegrationTest;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @IntegrationTest("src/test/projects/issue-449-artifact-restore")
 class Issue449Test {
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void installAfterCleanCompileShouldWork(Verifier verifier) throws VerificationException {
-        assumeFalse(SystemUtils.IS_OS_WINDOWS);
-
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("../log-0.txt");
@@ -47,5 +46,6 @@ class Issue449Test {
         verifier.verifyErrorFreeLog();
         verifier.verifyTextInLog("Found cached build, restoring");
         verifier.verifyTextInLog("Saved Build to local file");
+        verifier.verifyFilePresent("target/maven-build-cache-test-1.0-SNAPSHOT.jar");
     }
 }

--- a/src/test/projects/issue-449-artifact-restore/.gitattributes
+++ b/src/test/projects/issue-449-artifact-restore/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/test/projects/issue-449-artifact-restore/.gitignore
+++ b/src/test/projects/issue-449-artifact-restore/.gitignore
@@ -1,0 +1,4 @@
+.idea
+.code
+target
+/.m2-home

--- a/src/test/projects/issue-449-artifact-restore/.mvn/extensions.xml
+++ b/src/test/projects/issue-449-artifact-restore/.mvn/extensions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<extensions>
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>${projectVersion}</version>
+    </extension>
+</extensions>

--- a/src/test/projects/issue-449-artifact-restore/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/issue-449-artifact-restore/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+
+    <!--
+        Template Maven build cache configuration
+     -->
+
+    <configuration>
+        <enabled>true</enabled>
+        <hashAlgorithm>SHA-256</hashAlgorithm>
+        <validateXml>true</validateXml>
+        <mandatoryClean>true</mandatoryClean>
+        <remote enabled="false"></remote>
+        <local>
+            <maxBuildsCached>3</maxBuildsCached>
+        </local>
+        <projectVersioning adjustMetaInf="true"/>
+        <attachedOutputs>
+            <dirNames>
+                <dirName>classes</dirName>
+                <dirName>test-classes</dirName>
+                <dirName>generated-sources</dirName>
+                <dirName>generated-test-sources</dirName>
+                <dirName>antrun</dirName>
+                <dirName>quarkus-app</dirName>
+                <dirName>maven-archiver</dirName>
+                <dirName glob="test_backup.mv.db" />
+                <dirName glob="test_backup.NO_REGEN.db" />
+                <dirName glob="quarkus-artifact.properties" />
+            </dirNames>
+        </attachedOutputs>
+
+    </configuration>
+
+    <input>
+        <global>
+            <!-- If not defined, default glob is "*" -->
+            <glob>*</glob>
+            <includes>
+                <!-- By default, project sources and resources directories are included (src/main/java and src/main/resources) -->
+                <!-- In this example, the goal is to include a wider range of src directories (like src/main/assembly or src/main/groovy) -->
+                <include>src/</include>
+            </includes>
+            <excludes>
+                <!-- We don't want a static "hash" pom resolution (it would conflict the will to adjust the version in the manifest), -->
+                <!-- we exclude this specific file (as it is already by default since it is not in an include folder -->
+                <!-- The need to rebuild a project based on the pom is already computed with some intelligence by the extension. -->
+                <exclude>pom.xml</exclude>
+
+                <!-- Also excluding everything located in this project specific folder -->
+                <!-- <exclude>src/main/javagen/**</exclude> -->
+
+                <!-- liquibase stuff -->
+                <exclude glob="src/main/resources/META-INF/liquibase/**/full-changelog.xml" matcherType="PATH" entryType="FILE" />
+                <exclude glob="src/main/resources/META-INF/liquibase/**/generated"          matcherType="PATH" entryType="DIRECTORY" />
+            </excludes>
+        </global>
+        <plugins>
+            <plugin artifactId="formatter-maven-plugin">
+                <effectivePom>
+                    <excludeProperties>
+                        <excludeProperty>skipFormatting</excludeProperty>
+                    </excludeProperties>
+                </effectivePom>
+            </plugin>
+            <plugin artifactId="maven-surefire-plugin">
+                <effectivePom>
+                    <excludeProperties>
+                        <excludeProperty>skipTests</excludeProperty>
+                        <excludeProperty>skip</excludeProperty>
+                    </excludeProperties>
+                </effectivePom>
+            </plugin>
+            <plugin artifactId="maven-failsafe-plugin">
+                <effectivePom>
+                    <excludeProperties>
+                        <excludeProperty>skipTests</excludeProperty>
+                        <excludeProperty>skipITs</excludeProperty>
+                        <excludeProperty>skip</excludeProperty>
+                    </excludeProperties>
+                </effectivePom>
+            </plugin>
+        </plugins>
+    </input>
+    <executionControl>
+        <runAlways>
+            <plugins>
+                <plugin artifactId="maven-failsafe-plugin"/>
+                <plugin artifactId="maven-surefire-plugin"/>
+                <plugin artifactId="maven-toolchains-plugin"/>
+                <plugin artifactId="flatten-maven-plugin"/>
+            </plugins>
+            <executions>
+            </executions>
+            <goalsLists>
+                <goalsList artifactId="maven-install-plugin">
+                    <goals>
+                        <goal>install</goal>
+                    </goals>
+                </goalsList>
+                <goalsList artifactId="maven-deploy-plugin">
+                    <goals>
+                        <goal>deploy</goal>
+                    </goals>
+                </goalsList>
+            </goalsLists>
+        </runAlways>
+        <ignoreMissing>
+            <plugins>
+                <plugin artifactId="flatten-maven-plugin" />
+                <plugin artifactId="formatter-maven-plugin" />
+                <plugin artifactId="maven-clean-plugin" />
+            </plugins>
+        </ignoreMissing>
+        <reconcile>
+            <plugins>
+                <plugin artifactId="maven-surefire-plugin" goal="test">
+                    <reconciles>
+                        <reconcile propertyName="skipTests" skipValue="true"/>
+                        <reconcile propertyName="skip" skipValue="true"/>
+                    </reconciles>
+                </plugin>
+                <plugin artifactId="maven-failsafe-plugin" goal="test">
+                    <reconciles>
+                        <reconcile propertyName="skipTests" skipValue="true"/>
+                        <reconcile propertyName="skipITs" skipValue="true"/>
+                        <reconcile propertyName="skip" skipValue="true"/>
+                    </reconciles>
+                </plugin>
+                <plugin artifactId="formatter-maven-plugin" goal="format">
+                    <nologs>
+                        <nolog propertyName="skipFormatting"/>
+                    </nologs>
+                </plugin>
+                <plugin artifactId="export-properties-maven-plugin" goal="export-properties">
+                    <nologs>
+                        <nolog propertyName="properties"/>
+                    </nologs>
+                </plugin>
+                <plugin artifactId="echo-maven-plugin" goal="echo">
+                    <nologs>
+                        <nolog propertyName="message"/>
+                    </nologs>
+                </plugin>
+            </plugins>
+        </reconcile>
+    </executionControl>
+</cache>

--- a/src/test/projects/issue-449-artifact-restore/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/issue-449-artifact-restore/.mvn/maven-build-cache-config.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 -->
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
 
     <!--
         Template Maven build cache configuration

--- a/src/test/projects/issue-449-artifact-restore/pom.xml
+++ b/src/test/projects/issue-449-artifact-restore/pom.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>maven-build-cache-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.9.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.5.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.12.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.6.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.14.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <fork>true</fork>
+                    <compilerArgs combine.children="append">
+                        <arg>-Xlint:all,-processing,-path</arg>
+                        <arg>-Xdoclint:all,-missing,-accessibility</arg>
+                        <arg>-Xmaxerrs</arg>
+                        <arg>2147483647</arg>
+                        <arg>-Xmaxwarns</arg>
+                        <arg>2147483647</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <!--
+         id: attach-source
+
+         Attached an extra jar artifact containing the current source code.
+         This can be used in IDEs to browse the source, rather than having to check out the project.
+        -->
+        <profile>
+            <id>attach-source</id>
+            <activation>
+                <file>
+                    <missing>${basedir}/.tup/attach-source.disable</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/src/test/projects/issue-449-artifact-restore/src/main/java/test/MyService.java
+++ b/src/test/projects/issue-449-artifact-restore/src/main/java/test/MyService.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test;
+
+public final class MyService {
+
+    public static int oracle() {
+        return 42;
+    }
+
+}


### PR DESCRIPTION
Currently, the cached `target/classes` compile output is marked as the main project artifact when restoring the cache. This causes the issues described in #449. This PR ensures that only a "real" / JAR is marked as the project artifact when the cache is restored.

fixes #449

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
