### PR TITLE
fix: #480 - execute blocking hostname resolution asynchronously and implement timeout and caching

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache;
+
+import java.net.InetAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Resolves and caches the canonical host name of the local machine.
+ * <p>
+ * The lookup is performed asynchronously in a separate thread because
+ * {@code InetAddress.getLocalHost().getCanonicalHostName()} may block for a
+ * considerable amount of time in environments with slow or misconfigured name
+ * resolution (for example DNS or mDNS timeouts).
+ * <p>
+ * To avoid delaying application processing, the caller waits only up to
+ * {@value #TIMEOUT_MS} ms for the result. If the lookup does not complete in
+ * time or fails, the fallback value {@value #FALLBACK} is used instead.
+ * <p>
+ * The resolved value is cached after the first call to
+ * {@link #resolve()}.
+ */
+public final class HostnameResolver {
+
+    private static final String FALLBACK = "unknown";
+    private static final long TIMEOUT_MS = 1000;
+    private static String hostname;
+
+    private HostnameResolver() {
+        // utility class
+    }
+
+    public static String resolve() {
+        if (hostname == null) {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+
+                Future<String> future = executor.submit(() -> {
+                    try {
+                        return InetAddress.getLocalHost().getCanonicalHostName();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                });
+
+                String resolved;
+                try {
+                    resolved = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException e) {
+                    future.cancel(true);
+                    resolved = FALLBACK;
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    resolved = FALLBACK;
+                } catch (ExecutionException e) {
+                    resolved = FALLBACK;
+                }
+
+                hostname = (resolved == null || resolved.trim().isEmpty()) ? FALLBACK : resolved.trim();
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+
+        return hostname;
+    }
+}

--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -53,7 +53,12 @@ public final class HostnameResolver {
 
     public static String resolve() {
         if (hostname == null) synchronized (HostnameResolver.class) {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            });
+
             try {
 
                 Future<String> future = executor.submit(() -> {

--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -52,7 +52,7 @@ public final class HostnameResolver {
     }
 
     public static String resolve() {
-        if (hostname == null)
+        if (hostname == null) {
             synchronized (HostnameResolver.class) {
                 ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
                     Thread t = new Thread(r);
@@ -88,7 +88,7 @@ public final class HostnameResolver {
                     executor.shutdownNow();
                 }
             }
-
+        }
         return hostname;
     }
 }

--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -45,14 +45,14 @@ public final class HostnameResolver {
 
     private static final String FALLBACK = "unknown";
     private static final long TIMEOUT_MS = 1000;
-    private static String hostname;
+    private static volatile String hostname;
 
     private HostnameResolver() {
         // utility class
     }
 
     public static String resolve() {
-        if (hostname == null) {
+        if (hostname == null) synchronized (HostnameResolver.class) {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             try {
 

--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -52,41 +52,42 @@ public final class HostnameResolver {
     }
 
     public static String resolve() {
-        if (hostname == null) synchronized (HostnameResolver.class) {
-            ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
-                Thread t = new Thread(r);
-                t.setDaemon(true);
-                return t;
-            });
-
-            try {
-
-                Future<String> future = executor.submit(() -> {
-                    try {
-                        return InetAddress.getLocalHost().getCanonicalHostName();
-                    } catch (Exception e) {
-                        return null;
-                    }
+        if (hostname == null)
+            synchronized (HostnameResolver.class) {
+                ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+                    Thread t = new Thread(r);
+                    t.setDaemon(true);
+                    return t;
                 });
 
-                String resolved;
                 try {
-                    resolved = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                } catch (TimeoutException e) {
-                    future.cancel(true);
-                    resolved = FALLBACK;
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    resolved = FALLBACK;
-                } catch (ExecutionException e) {
-                    resolved = FALLBACK;
-                }
 
-                hostname = (resolved == null || resolved.trim().isEmpty()) ? FALLBACK : resolved.trim();
-            } finally {
-                executor.shutdownNow();
+                    Future<String> future = executor.submit(() -> {
+                        try {
+                            return InetAddress.getLocalHost().getCanonicalHostName();
+                        } catch (Exception e) {
+                            return null;
+                        }
+                    });
+
+                    String resolved;
+                    try {
+                        resolved = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                    } catch (TimeoutException e) {
+                        future.cancel(true);
+                        resolved = FALLBACK;
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        resolved = FALLBACK;
+                    } catch (ExecutionException e) {
+                        resolved = FALLBACK;
+                    }
+
+                    hostname = (resolved == null || resolved.trim().isEmpty()) ? FALLBACK : resolved.trim();
+                } finally {
+                    executor.shutdownNow();
+                }
             }
-        }
 
         return hostname;
     }

--- a/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
+++ b/src/main/java/org/apache/maven/buildcache/HostnameResolver.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeoutException;
 public final class HostnameResolver {
 
     private static final String FALLBACK = "unknown";
-    private static final long TIMEOUT_MS = 1000;
+    protected static final long TIMEOUT_MS = 1000;
     private static volatile String hostname;
 
     private HostnameResolver() {

--- a/src/main/java/org/apache/maven/buildcache/xml/Build.java
+++ b/src/main/java/org/apache/maven/buildcache/xml/Build.java
@@ -19,8 +19,6 @@
 package org.apache.maven.buildcache.xml;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -30,6 +28,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.maven.buildcache.CacheUtils;
+import org.apache.maven.buildcache.HostnameResolver;
 import org.apache.maven.buildcache.checksum.MavenProjectInput;
 import org.apache.maven.buildcache.hash.HashAlgorithm;
 import org.apache.maven.buildcache.xml.build.Artifact;
@@ -60,11 +59,7 @@ public class Build {
         this.dto = new org.apache.maven.buildcache.xml.build.Build();
         this.dto.setCacheImplementationVersion(MavenProjectInput.CACHE_IMPLEMENTATION_VERSION);
         this.dto.setBuildTime(new Date());
-        try {
-            this.dto.setBuildServer(InetAddress.getLocalHost().getCanonicalHostName());
-        } catch (UnknownHostException ignore) {
-            this.dto.setBuildServer("unknown");
-        }
+        this.dto.setBuildServer(HostnameResolver.resolve());
         this.dto.setHashFunction(hashAlgorithm);
         this.dto.setArtifact(artifact);
         this.dto.setGoals(goals);

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -29,8 +29,8 @@ class HostnameResolverTest {
     void testResolve() {
         long start = System.currentTimeMillis();
         String hostname = HostnameResolver.resolve();
-        assertNotNull(hostname);
         long duration = System.currentTimeMillis() - start;
         assertTrue(duration <= HostnameResolver.TIMEOUT_MS);
+        assertNotNull(hostname);
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -20,8 +20,8 @@ package org.apache.maven.buildcache;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class HostnameResolverTest {
 

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -1,0 +1,15 @@
+package org.apache.maven.buildcache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HostnameResolverTest {
+
+    @Test
+    void testResolve() {
+        assertNotNull(HostnameResolver.resolve());
+        assertNotEquals("unknown", HostnameResolver.resolve());
+    }
+
+}

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -20,7 +20,8 @@ package org.apache.maven.buildcache;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class HostnameResolverTest {
 

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -21,16 +21,14 @@ package org.apache.maven.buildcache;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class HostnameResolverTest {
 
     @Test
     void testResolve() {
-        long start = System.currentTimeMillis();
         String hostname = HostnameResolver.resolve();
-        long duration = System.currentTimeMillis() - start;
-        assertTrue(duration <= HostnameResolver.TIMEOUT_MS);
         assertNotNull(hostname);
+        assertFalse(hostname.isBlank());
     }
 }

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.maven.buildcache;
 
 import org.junit.jupiter.api.Test;
@@ -11,5 +29,4 @@ class HostnameResolverTest {
         assertNotNull(HostnameResolver.resolve());
         assertNotEquals("unknown", HostnameResolver.resolve());
     }
-
 }

--- a/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
+++ b/src/test/java/org/apache/maven/buildcache/HostnameResolverTest.java
@@ -20,14 +20,17 @@ package org.apache.maven.buildcache;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HostnameResolverTest {
 
     @Test
     void testResolve() {
-        assertNotNull(HostnameResolver.resolve());
-        assertNotEquals("unknown", HostnameResolver.resolve());
+        long start = System.currentTimeMillis();
+        String hostname = HostnameResolver.resolve();
+        assertNotNull(hostname);
+        long duration = System.currentTimeMillis() - start;
+        assertTrue(duration <= HostnameResolver.TIMEOUT_MS);
     }
 }


### PR DESCRIPTION
This PR addresses issue #480 

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
