### PR TITLE
Issue #492 restore compile-only reactor module so downstream resoluti…

### DIFF
--- a/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/CacheControllerImpl.java
@@ -481,6 +481,13 @@ public class CacheControllerImpl implements CacheController {
                 if (!project.hasLifecyclePhase("package")) {
                     project.addLifecyclePhase("package");
                 }
+            } else if (restoredProjectArtifact != null) {
+                // Directory artifact (target/classes from compile-only build).
+                // Point the existing project artifact at the restored directory so reactor dependency
+                // resolution can locate this module's compiled output. Don't replace the artifact:
+                // RestoredArtifact.getFile() always re-routes through restoreToDiskConsumer, which would
+                // break later phases (e.g. jar:jar) that update the file via setFile().
+                project.getArtifact().setFile(restoredProjectArtifact.getFile());
             }
             restoredAttachedArtifacts.forEach(project::addAttachedArtifact);
             restorationReport.setSuccess(true);

--- a/src/test/java/org/apache/maven/buildcache/its/CompileOnlyReactorRestoreTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/CompileOnlyReactorRestoreTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.buildcache.its;
+
+import java.util.Arrays;
+
+import org.apache.maven.buildcache.its.junit.IntegrationTest;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproducer for <a href="https://github.com/apache/maven-build-cache-extension/issues/492">Issue #492</a>:
+ * {@code clean compile} twice in a multi-module reactor fails to resolve the upstream module.
+ *
+ * <p>On the second run the cache extension restores the upstream module's compiled
+ * output but, because no jar was produced in the original cached build, downstream
+ * dependency resolution falls through to remote repositories with
+ * {@code Could not find artifact ...:jar:...-SNAPSHOT}.
+ */
+@IntegrationTest("src/test/projects/issue-393-compile-restore")
+class CompileOnlyReactorRestoreTest {
+
+    @Test
+    void cleanCompileTwiceResolvesUpstreamFromReactorCache(Verifier verifier) throws VerificationException {
+        verifier.setAutoclean(false);
+
+        verifier.setLogFileName("../log-compile-1.txt");
+        verifier.executeGoals(Arrays.asList("clean", "compile"));
+        verifier.verifyErrorFreeLog();
+
+        verifier.setLogFileName("../log-compile-2.txt");
+        verifier.executeGoals(Arrays.asList("clean", "compile"));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog(
+                "Found cached build, restoring org.apache.maven.caching.test.jpms:issue-393-app from cache");
+        verifier.verifyTextInLog("Skipping plugin execution (cached): compiler:compile");
+        verifier.verifyFilePresent("app/target/classes/module-info.class");
+        verifier.verifyFilePresent("consumer/target/classes/module-info.class");
+    }
+}


### PR DESCRIPTION
Fixes #492

## Description

`restoreProjectArtifacts` only wires up `project.getArtifact()` to a restored artifact when the cached file is a regular jar. For compile-only cached builds the primary cached artifact is the `target/classes` directory, which falls through that condition unset. In a multi-module reactor that leaves downstream modules unable to resolve the upstream as a reactor artifact on a subsequent `mvn clean compile`, and they fall through to remote repositories with `Could not find artifact ...:jar:...-SNAPSHOT`.

For the directory case this PR sets the file on the existing project artifact instead of replacing it with a `RestoredArtifact`. `RestoredArtifact.getFile` routes through `restoreToDiskConsumer` on every call, which would later break package-phase plugins (e.g. `jar:jar`) that update the file via `setFile`.

Added `CompileOnlyReactorRestoreTest`, which reuses the existing `issue-393-compile-restore` reactor project to exercise two consecutive compile-only invocations. The test fails on master and passes with this change.

## Checklist

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
