### PR TITLE
Reverse Maven versions

### DIFF
--- a/.github/workflows/maven-verify-3.10.x.yml
+++ b/.github/workflows/maven-verify-3.10.x.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify 3.9.x
+name: Verify 3.10.x
 
 on:
   push:
@@ -26,9 +26,8 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven3"'
+      maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven3.10"'
       maven4-enabled: false
-      matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'
 

--- a/.github/workflows/maven-verify-3.10.x.yml
+++ b/.github/workflows/maven-verify-3.10.x.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify 3.10.x
+name: Verify 3.10
 
 on:
   push:

--- a/.github/workflows/maven-verify-3.10.x.yml
+++ b/.github/workflows/maven-verify-3.10.x.yml
@@ -27,6 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-enabled: false
+      matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its,maven3.10 verify javadoc:jar'
       verify-goal: '-P run-its,maven3.10 verify javadoc:jar'
 

--- a/.github/workflows/maven-verify-3.10.x.yml
+++ b/.github/workflows/maven-verify-3.10.x.yml
@@ -26,8 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven3.10"'
       maven4-enabled: false
-      ff-goal: '-P run-its verify javadoc:jar'
-      verify-goal: '-P run-its verify javadoc:jar'
+      ff-goal: '-P run-its,maven3.10 verify javadoc:jar'
+      verify-goal: '-P run-its,maven3.10 verify javadoc:jar'
 

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -26,9 +26,8 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven4.0"'
       maven4-enabled: true
       matrix-exclude: '[ {"jdk": "8"} ]'
-      ff-goal: '-P run-its verify javadoc:jar'
-      verify-goal: '-P run-its verify javadoc:jar'
+      ff-goal: '-P run-its,maven4.0 verify javadoc:jar'
+      verify-goal: '-P run-its,maven4.0 verify javadoc:jar'
 

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -15,12 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify 4.0.x
+name: Verify 4.0
 
-# Disabled until we can get Maven 4.0.x to run in CI (migrate to maven-executor)
-#on:
-#  push:
-#  pull_request:
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -26,7 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven4-enabled: true
+      maven4-enabled: false # no: we manually download and run tests with Maven 4
       matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its,maven4.0 verify javadoc:jar'
       verify-goal: '-P run-its,maven4.0 verify javadoc:jar'

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -17,9 +17,10 @@
 
 name: Verify 4.0.x
 
-on:
-  push:
-  pull_request:
+# Disabled until we can get Maven 4.0.x to run in CI (migrate to maven-executor)
+#on:
+#  push:
+#  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -17,9 +17,10 @@
 
 name: Verify 4.0
 
-on:
-  push:
-  pull_request:
+# Maven 4 disabled for now: let's focus on Resolver 2 first
+# on:
+#  push:
+#  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify 3.9.x
+name: Verify 4.0.x
 
 on:
   push:
@@ -26,7 +26,9 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven-args: '-D"maven.test.redirectTestOutputToFile=false"'
-      maven4-enabled: true
+      maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven4.0"'
+      maven4-enabled: false
+      matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'
+

--- a/.github/workflows/maven-verify-4.0.x.yml
+++ b/.github/workflows/maven-verify-4.0.x.yml
@@ -27,7 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven-args: '-D"maven.test.redirectTestOutputToFile=false -Pmaven4.0"'
-      maven4-enabled: false
+      maven4-enabled: true
       matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify 3.9.x
+name: Verify 3.9
 
 on:
   push:

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,7 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      maven-args: '-D"maven.test.redirectTestOutputToFile=false"'
       maven4-enabled: false
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,6 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-enabled: false
+      matrix-exclude: '[ {"jdk": "8"} ]'
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,6 +27,6 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven-args: '-D"maven.test.redirectTestOutputToFile=false"'
-      maven4-enabled: true
+      maven4-enabled: false
       ff-goal: '-P run-its verify javadoc:jar'
       verify-goal: '-P run-its verify javadoc:jar'

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ under the License.
 
     <!-- default maven version, will be overridden by mavenX profile -->
     <mavenVersion>3.9.16</mavenVersion>
-    <maven.dir>maven4</maven.dir>
+    <maven.dir>maven3.9</maven.dir>
     <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
 
     <commonsCliVersion>1.4</commonsCliVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -237,11 +237,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.executor</groupId>
-      <artifactId>maven-executor-verifier</artifactId>
-      <version>1.0.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4jVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@ under the License.
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <classWorldsVersion>2.6.0</classWorldsVersion>
 
-    <!-- default maven version, will be overridden by maven3 profile -->
-    <mavenVersion>4.0.0-alpha-8</mavenVersion>
+    <!-- default maven version, will be overridden by mavenX profile -->
+    <mavenVersion>3.9.16</mavenVersion>
     <maven.dir>maven4</maven.dir>
     <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
 
@@ -571,10 +571,18 @@ under the License.
       </build>
     </profile>
     <profile>
-      <id>maven3</id>
+      <id>maven3.10</id>
       <properties>
-        <mavenVersion>3.9.16</mavenVersion>
-        <maven.dir>maven3</maven.dir>
+        <mavenVersion>3.10.0-rc-1</mavenVersion>
+        <maven.dir>maven3.10</maven.dir>
+        <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
+      </properties>
+    </profile>
+    <profile>
+      <id>maven4.0</id>
+      <properties>
+        <mavenVersion>4.0.0-rc-5</mavenVersion>
+        <maven.dir>maven4.0</maven.dir>
         <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,10 @@ under the License.
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <classWorldsVersion>2.6.0</classWorldsVersion>
 
-    <!-- default maven version, will be overridden by mavenX profile -->
+    <!-- default maven version we build against -->
     <mavenVersion>3.9.16</mavenVersion>
+    <!-- default maven version we test against, will be overridden by mavenX profile -->
+    <maven.version>${mavenVersion}</maven.version>
     <maven.dir>maven3.9</maven.dir>
     <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
 
@@ -469,7 +471,7 @@ under the License.
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>apache-maven</artifactId>
-                  <version>${mavenVersion}</version>
+                  <version>${maven.version}</version>
                   <classifier>bin</classifier>
                   <type>tar.gz</type>
                   <overWrite>false</overWrite>
@@ -573,7 +575,7 @@ under the License.
     <profile>
       <id>maven3.10</id>
       <properties>
-        <mavenVersion>3.10.0-rc-1</mavenVersion>
+        <maven.version>3.10.0-rc-1</maven.version>
         <maven.dir>maven3.10</maven.dir>
         <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
       </properties>
@@ -581,7 +583,7 @@ under the License.
     <profile>
       <id>maven4.0</id>
       <properties>
-        <mavenVersion>4.0.0-rc-5</mavenVersion>
+        <maven.version>4.0.0-rc-5</maven.version>
         <maven.dir>maven4.0</maven.dir>
         <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,19 +72,10 @@ under the License.
     <maven.dir>maven3.9</maven.dir>
     <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
 
-    <commonsCliVersion>1.4</commonsCliVersion>
-    <commonsLangVersion>3.20.0</commonsLangVersion>
-    <junit.version>5.14.4</junit.version>
-    <mockitoVersion>4.11.0</mockitoVersion>
-    <wagonVersion>3.4.3</wagonVersion>
-    <securityDispatcherVersion>2.0</securityDispatcherVersion>
-    <cipherVersion>2.0</cipherVersion>
-    <modelloVersion>1.11</modelloVersion>
-    <jxpathVersion>1.3</jxpathVersion>
+    <wagonVersion>3.5.3</wagonVersion>
     <resolverVersion>1.9.27</resolverVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <wiremockVersion>3.0.1</wiremockVersion>
-    <xmlunitVersion>2.6.4</xmlunitVersion>
+    <mockitoVersion>4.11.0</mockitoVersion>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <maven.site.path>extensions-archives/${project.artifactId}-LATEST</maven.site.path>
   </properties>
@@ -101,7 +92,7 @@ under the License.
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${junit.version}</version>
+        <version>5.14.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -171,7 +162,7 @@ under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commonsLangVersion}</version>
+      <version>3.20.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -213,37 +204,26 @@ under the License.
       <artifactId>slf4j-api</artifactId>
       <version>${slf4jVersion}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-webdav-jackrabbit</artifactId>
-      <version>3.5.3</version>
+      <version>${wagonVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>3.5.3</version>
+      <version>${wagonVersion}</version>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-verifier</artifactId>
-      <version>1.8.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-embedder</artifactId>
-      <version>${mavenVersion}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -255,6 +235,11 @@ under the License.
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.executor</groupId>
+      <artifactId>maven-executor-verifier</artifactId>
+      <version>1.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -293,20 +278,15 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>${mockitoVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>${wiremockVersion}</version>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>3.13.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -319,6 +299,20 @@ under the License.
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- To be removed (replace with maven-executor) -->
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-verifier</artifactId>
+      <version>1.8.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
@@ -367,11 +361,6 @@ under the License.
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.10.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
@@ -178,7 +178,13 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         Class<?> currentClass = ex.getClass();
 
         while (currentClass != null) {
+            // Apache HttpClient 4.x
             if ("org.apache.http.client.HttpResponseException".equals(currentClass.getName())) {
+                return true;
+            }
+            // Resolver 2 generic; used by all clients
+            if ("org.eclipse.aether.spi.connector.transport.http.HttpTransporterException"
+                    .equals(currentClass.getName())) {
                 return true;
             }
             currentClass = currentClass.getSuperclass();

--- a/src/site/markdown/remote-cache.md
+++ b/src/site/markdown/remote-cache.md
@@ -143,7 +143,7 @@ from Maven 3.9.1 and 4.0.0-alpha5, support of webdav has been removed per defaul
 You need to use the following extra configuration:
 
 ```bash
--Daether.connector.http.supportWebDav=true
+-Daether.transport.http.supportWebDav=true
 OR
 -Dmaven.resolver.transport=wagon
 ```

--- a/src/site/markdown/remote-cache.md
+++ b/src/site/markdown/remote-cache.md
@@ -143,8 +143,8 @@ from Maven 3.9.1 and 4.0.0-alpha5, support of webdav has been removed per defaul
 You need to use the following extra configuration:
 
 ```bash
--Daether.transport.http.supportWebDav # mvn 3.10+
--Daether.connector.http.supportWebDav # mvn 3.9
+-Daether.transport.http.supportWebDav=true # mvn 3.10+
+-Daether.connector.http.supportWebDav=true # mvn 3.9
 OR
 -Dmaven.resolver.transport=wagon
 ```

--- a/src/site/markdown/remote-cache.md
+++ b/src/site/markdown/remote-cache.md
@@ -143,7 +143,8 @@ from Maven 3.9.1 and 4.0.0-alpha5, support of webdav has been removed per defaul
 You need to use the following extra configuration:
 
 ```bash
--Daether.transport.http.supportWebDav=true
+-Daether.transport.http.supportWebDav # mvn 3.10+
+-Daether.connector.http.supportWebDav # mvn 3.9
 OR
 -Dmaven.resolver.transport=wagon
 ```

--- a/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
@@ -60,7 +60,7 @@ class BuildExtensionTest {
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
         verifier.addCliOption("-D" + SKIP_SAVE + "=true");
-        verifier.addCliOption("--debug");
+        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
@@ -60,7 +60,7 @@ class BuildExtensionTest {
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
         verifier.addCliOption("-D" + SKIP_SAVE + "=true");
-        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/BuildExtensionTest.java
@@ -60,7 +60,7 @@ class BuildExtensionTest {
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
         verifier.addCliOption("-D" + SKIP_SAVE + "=true");
-        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X");
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/DuplicateGoalsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/DuplicateGoalsTest.java
@@ -36,7 +36,7 @@ class DuplicateGoalsTest {
 
         // run with an extra goal
         verifier.setLogFileName("../log-1.txt");
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
         verifier.executeGoals(Arrays.asList("compile", "test"));
         verifier.verifyErrorFreeLog();
 

--- a/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionCoreExtensionTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.buildcache.its;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.buildcache.its.junit.IntegrationTest;
@@ -59,9 +59,8 @@ class ForkedExecutionCoreExtensionTest {
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("../log-1.txt");
-        verifier.setMavenDebug(true);
         verifier.setCliOptions(
-                Collections.singletonList("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath()));
+                Arrays.asList("-X", "-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath()));
         verifier.executeGoal("verify");
         verifier.verifyTextInLog("Started forked project");
         // forked execution actually runs
@@ -77,6 +76,8 @@ class ForkedExecutionCoreExtensionTest {
         verifier.verifyTextInLog("[INFO] BUILD SUCCESS");
 
         verifier.setLogFileName("../log-2.txt");
+        verifier.setCliOptions(
+                Arrays.asList("-X", "-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath()));
         verifier.executeGoal("verify");
         verifier.verifyErrorFreeLog();
         verifier.verifyTextInLog("Found cached build, restoring " + PROJECT_NAME + " from cache");

--- a/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ForkedExecutionsTest.java
@@ -84,8 +84,8 @@ class ForkedExecutionsTest {
         verifier.setAutoclean(false);
 
         verifier.setLogFileName("../log-1.txt");
-        verifier.setMavenDebug(true);
         verifier.setCliOptions(Arrays.asList(
+                "-X",
                 "-Dmaven.build.cache.location=" + tempDirectory.toAbsolutePath(),
                 "-Dmaven.build.cache.remote.url=http:////localhost:"
                         + wm.getRuntimeInfo().getHttpPort(),

--- a/src/test/java/org/apache/maven/buildcache/its/IncludeExcludeTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/IncludeExcludeTest.java
@@ -44,7 +44,7 @@ class IncludeExcludeTest {
     @Test
     void includeExclude(Verifier verifier) throws VerificationException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
 
         // First build
         verifier.setLogFileName("../log-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/IncrementalRestoreTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/IncrementalRestoreTest.java
@@ -103,7 +103,7 @@ class IncrementalRestoreTest {
     @Test
     void simple(Verifier verifier) throws VerificationException, IOException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
 
         initialBuild(verifier);
         verifyPackageWithCache(verifier);
@@ -253,7 +253,6 @@ class IncrementalRestoreTest {
     }
 
     private void cleanBuild(Verifier verifier) throws VerificationException {
-        verifier.setMavenDebug(false);
         verifier.setLogFileName("../log-clean.txt");
         verifier.executeGoal("clean");
         verifier.verifyFileNotPresent(GENERATED_JAR);

--- a/src/test/java/org/apache/maven/buildcache/its/Issue463Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue463Test.java
@@ -134,7 +134,8 @@ class Issue463Test {
         verifier.setAutoclean(false);
         verifier.addCliOption("--settings=" + settings);
         // Allow Aether to create WebDAV collection (directory) hierarchy via MKCOL
-        verifier.setSystemProperty("aether.transport.http.supportWebDav", "true");
+        verifier.setSystemProperty("aether.transport.http.supportWebDav", "true"); // Maven 3.10+
+        verifier.setSystemProperty("aether.connector.http.supportWebDav", "true"); // Maven 3.9
 
         // ── Step 1: Runner A builds with skipTests=true, saves incomplete entry to remote ────────
         verifier.setSystemProperty(CACHE_LOCATION_PROPERTY_NAME, localCacheA.toString());

--- a/src/test/java/org/apache/maven/buildcache/its/Issue463Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue463Test.java
@@ -134,7 +134,7 @@ class Issue463Test {
         verifier.setAutoclean(false);
         verifier.addCliOption("--settings=" + settings);
         // Allow Aether to create WebDAV collection (directory) hierarchy via MKCOL
-        verifier.setSystemProperty("aether.connector.http.supportWebDav", "true");
+        verifier.setSystemProperty("aether.transport.http.supportWebDav", "true");
 
         // ── Step 1: Runner A builds with skipTests=true, saves incomplete entry to remote ────────
         verifier.setSystemProperty(CACHE_LOCATION_PROPERTY_NAME, localCacheA.toString());

--- a/src/test/java/org/apache/maven/buildcache/its/Issue67Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue67Test.java
@@ -43,7 +43,7 @@ class Issue67Test {
     @Test
     void simple(Verifier verifier) throws VerificationException, IOException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
 
         // First build, nothing in cache
         verifier.setLogFileName("../log.txt");
@@ -62,7 +62,6 @@ class Issue67Test {
                 Files.deleteIfExists(Paths.get(jarCachePath)), "mbuildcache-67.jar was expected in the local cache");
 
         // Second build, with a corrupted cache
-        verifier.setMavenDebug(false);
         verifier.setLogFileName("../log-2.txt");
         verifier.executeGoal("clean");
         verifier.verifyFileNotPresent(GENERATED_JAR);

--- a/src/test/java/org/apache/maven/buildcache/its/Issue74Test.java
+++ b/src/test/java/org/apache/maven/buildcache/its/Issue74Test.java
@@ -46,7 +46,7 @@ class Issue74Test {
     @Test
     void simple(Verifier verifier) throws VerificationException, IOException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
 
         // first run - uncached
         verifier.setLogFileName("../log-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
@@ -52,7 +52,7 @@ class MandatoryCleanTest {
         Path tempDirectory = Files.createTempDirectory("simple-mandatory-clean");
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
-        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X");
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -100,7 +100,7 @@ class MandatoryCleanTest {
     void disabledViaProperty(Verifier verifier) throws VerificationException {
 
         verifier.setAutoclean(false);
-        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X");
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -120,7 +120,7 @@ class MandatoryCleanTest {
 
         verifier.setLogFileName("../log-2.txt");
         verifier.getCliOptions().clear();
-        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X");
         // With "true", we do not change the initially expected behaviour
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=true");
         verifier.executeGoal("verify");
@@ -140,7 +140,7 @@ class MandatoryCleanTest {
 
         // With "false", we remove the need for the clean phase
         verifier.getCliOptions().clear();
-        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X");
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=false");
         verifier.setLogFileName("../log-3.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
@@ -52,7 +52,7 @@ class MandatoryCleanTest {
         Path tempDirectory = Files.createTempDirectory("simple-mandatory-clean");
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
-        verifier.addCliOption("--debug");
+        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -100,7 +100,7 @@ class MandatoryCleanTest {
     void disabledViaProperty(Verifier verifier) throws VerificationException {
 
         verifier.setAutoclean(false);
-        verifier.addCliOption("--debug");
+        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -120,7 +120,7 @@ class MandatoryCleanTest {
 
         verifier.setLogFileName("../log-2.txt");
         verifier.getCliOptions().clear();
-        verifier.addCliOption("--debug");
+        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
         // With "true", we do not change the initially expected behaviour
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=true");
         verifier.executeGoal("verify");
@@ -140,7 +140,7 @@ class MandatoryCleanTest {
 
         // With "false", we remove the need for the clean phase
         verifier.getCliOptions().clear();
-        verifier.addCliOption("--debug");
+        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=false");
         verifier.setLogFileName("../log-3.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/MandatoryCleanTest.java
@@ -52,7 +52,7 @@ class MandatoryCleanTest {
         Path tempDirectory = Files.createTempDirectory("simple-mandatory-clean");
         verifier.getCliOptions().clear();
         verifier.addCliOption("-D" + CACHE_LOCATION_PROPERTY_NAME + "=" + tempDirectory.toAbsolutePath());
-        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -100,7 +100,7 @@ class MandatoryCleanTest {
     void disabledViaProperty(Verifier verifier) throws VerificationException {
 
         verifier.setAutoclean(false);
-        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
 
         verifier.setLogFileName("../log-1.txt");
         verifier.executeGoal("verify");
@@ -120,7 +120,7 @@ class MandatoryCleanTest {
 
         verifier.setLogFileName("../log-2.txt");
         verifier.getCliOptions().clear();
-        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
         // With "true", we do not change the initially expected behaviour
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=true");
         verifier.executeGoal("verify");
@@ -140,7 +140,7 @@ class MandatoryCleanTest {
 
         // With "false", we remove the need for the clean phase
         verifier.getCliOptions().clear();
-        verifier.addCliOption("--verbose"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
+        verifier.addCliOption("-X"); // --debug means REMOTE DEBUGGING with Maven 4 (and always was)
         verifier.addCliOption("-D" + CacheConfigImpl.MANDATORY_CLEAN + "=false");
         verifier.setLogFileName("../log-3.txt");
         verifier.executeGoal("verify");

--- a/src/test/java/org/apache/maven/buildcache/its/ReconcileExpressionsTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ReconcileExpressionsTest.java
@@ -144,7 +144,7 @@ class ReconcileExpressionsTest {
     @Test
     void multipleExpressionsEvaluated(Verifier verifier) throws VerificationException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(true);
+        verifier.addCliOption("-X");
 
         // Build with debug to see expression evaluation
         verifier.setLogFileName("../log-multi-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/ReferenceProjectBootstrap.java
+++ b/src/test/java/org/apache/maven/buildcache/its/ReferenceProjectBootstrap.java
@@ -230,7 +230,7 @@ public class ReferenceProjectBootstrap {
         // Pre-install prerequisite sub-projects (e.g. external parent POMs, relocated artifacts)
         for (String subDir : preInstallDirs) {
             Path subProjectDir = projectDir.resolve(subDir);
-            Verifier preInstaller = new Verifier(subProjectDir.toString(), true);
+            Verifier preInstaller = new Verifier(subProjectDir.toString());
             preInstaller.setLogFileName("../../pre-install-" + subDir + ".txt");
             preInstaller.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
             preInstaller.setLocalRepo(localRepo);
@@ -239,7 +239,7 @@ public class ReferenceProjectBootstrap {
             preInstaller.verifyErrorFreeLog();
         }
 
-        Verifier verifier = new Verifier(projectDir.toString(), true);
+        Verifier verifier = new Verifier(projectDir.toString());
         verifier.setLogFileName("../log.txt");
         verifier.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
         verifier.setLocalRepo(localRepo);

--- a/src/test/java/org/apache/maven/buildcache/its/RemoteCacheDavTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/RemoteCacheDavTest.java
@@ -153,6 +153,7 @@ class RemoteCacheDavTest {
         verifier.getCliOptions().clear();
         verifier.addCliOption("--settings=" + settings);
         if (!"wagon".equals(transport)) {
+            verifier.setSystemProperty("aether.transport.http.supportWebDav", "true");
             verifier.setSystemProperty("aether.connector.http.supportWebDav", "true");
         }
         verifier.addCliOption("-D" + HTTP_TRANSPORT_PRIORITY + "=" + ("wagon".equals(transport) ? "0" : "10"));
@@ -170,6 +171,7 @@ class RemoteCacheDavTest {
         verifier.getCliOptions().clear();
         verifier.addCliOption("--settings=" + settings);
         if (!"wagon".equals(transport)) {
+            verifier.setSystemProperty("aether.transport.http.supportWebDav", "true");
             verifier.setSystemProperty("aether.connector.http.supportWebDav", "true");
         }
         verifier.addCliOption("-D" + HTTP_TRANSPORT_PRIORITY + "=" + ("wagon".equals(transport) ? "0" : "10"));

--- a/src/test/java/org/apache/maven/buildcache/its/junit/IntegrationTestExtension.java
+++ b/src/test/java/org/apache/maven/buildcache/its/junit/IntegrationTestExtension.java
@@ -150,7 +150,7 @@ public class IntegrationTestExtension implements BeforeAllCallback, BeforeEachCa
                 });
             }
 
-            Verifier verifier = new Verifier(testExecutionDir.toString(), true);
+            Verifier verifier = new Verifier(testExecutionDir.toString());
             verifier.setLogFileName("../log.txt");
             verifier.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
             verifier.setLocalRepo(System.getProperty("localRepo"));

--- a/src/test/java/org/apache/maven/buildcache/its/pluginexecution/LogAllPropertiesTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/pluginexecution/LogAllPropertiesTest.java
@@ -50,7 +50,6 @@ class LogAllPropertiesTest {
     @Test
     void logAllPropertiesRecordsNonTrackedParameters(Verifier verifier) throws VerificationException, IOException {
         verifier.setAutoclean(false);
-        verifier.setMavenDebug(false);
 
         // Build 1 — logAllProperties=true is in the cache config; all surefire parameters recorded
         verifier.setLogFileName("../log-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/remote/BaselineDiffTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/remote/BaselineDiffTest.java
@@ -100,6 +100,9 @@ class BaselineDiffTest {
         verifier.setAutoclean(false);
         verifier.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifier.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
+        verifier.setSystemProperty(
+                "aether.transport.http.supportWebDav",
+                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
 
         // ── Build 1: push baseline artifacts and build-cache-report.xml to WireMock ──────────
         verifier.setLogFileName("../log-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/remote/BaselineDiffTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/remote/BaselineDiffTest.java
@@ -100,9 +100,8 @@ class BaselineDiffTest {
         verifier.setAutoclean(false);
         verifier.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifier.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
-        verifier.setSystemProperty(
-                "aether.transport.http.supportWebDav",
-                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
+        verifier.setSystemProperty("aether.transport.http.supportWebDav", "true"); // Maven 3.10+
+        verifier.setSystemProperty("aether.connector.http.supportWebDav", "true"); // Maven 3.9
 
         // ── Build 1: push baseline artifacts and build-cache-report.xml to WireMock ──────────
         verifier.setLogFileName("../log-1.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/remote/SaveFinalRemoteTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/remote/SaveFinalRemoteTest.java
@@ -92,6 +92,9 @@ class SaveFinalRemoteTest {
         verifierA.setAutoclean(false);
         verifierA.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifierA.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
+        verifierA.setSystemProperty(
+                "aether.transport.http.supportWebDav",
+                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
         // maven.build.cache.remote.save.final defaults to false — not set explicitly
 
         verifierA.setLogFileName("../log-normal.txt");
@@ -120,6 +123,9 @@ class SaveFinalRemoteTest {
         verifierB.setAutoclean(false);
         verifierB.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifierB.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
+        verifierB.setSystemProperty(
+                "aether.transport.http.supportWebDav",
+                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
         verifierB.setSystemProperty("maven.build.cache.remote.save.final", "true");
 
         verifierB.setLogFileName("../log-final.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/remote/SaveFinalRemoteTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/remote/SaveFinalRemoteTest.java
@@ -92,9 +92,8 @@ class SaveFinalRemoteTest {
         verifierA.setAutoclean(false);
         verifierA.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifierA.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
-        verifierA.setSystemProperty(
-                "aether.transport.http.supportWebDav",
-                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
+        verifierA.setSystemProperty("aether.transport.http.supportWebDav", "true"); // Maven 3.10+
+        verifierA.setSystemProperty("aether.connector.http.supportWebDav", "true"); // Maven 3.9
         // maven.build.cache.remote.save.final defaults to false — not set explicitly
 
         verifierA.setLogFileName("../log-normal.txt");
@@ -123,9 +122,8 @@ class SaveFinalRemoteTest {
         verifierB.setAutoclean(false);
         verifierB.setSystemProperty("maven.build.cache.remote.url", remoteUrl);
         verifierB.setSystemProperty("maven.build.cache.remote.save.enabled", "true");
-        verifierB.setSystemProperty(
-                "aether.transport.http.supportWebDav",
-                "true"); // Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
+        verifierB.setSystemProperty("aether.transport.http.supportWebDav", "true"); // Maven 3.10+
+        verifierB.setSystemProperty("aether.connector.http.supportWebDav", "true"); // Maven 3.9
         verifierB.setSystemProperty("maven.build.cache.remote.save.final", "true");
 
         verifierB.setLogFileName("../log-final.txt");

--- a/src/test/java/org/apache/maven/buildcache/its/versioning/CIFriendlyRevisionVersionTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/versioning/CIFriendlyRevisionVersionTest.java
@@ -76,7 +76,7 @@ class CIFriendlyRevisionVersionTest {
         // Build 2 — revision=2.0 (different version, same source).
         // The version string is normalized in the effective-POM fingerprint, so the cache key
         // is the same as build 1 → cache HIT.
-        Verifier verifier2 = new Verifier(verifier.getBasedir(), true);
+        Verifier verifier2 = new Verifier(verifier.getBasedir());
         verifier2.setAutoclean(false);
         verifier2.setLogFileName("../log-2.txt");
         verifier2.setSystemProperty("projectVersion", System.getProperty("projectVersion"));

--- a/src/test/java/org/apache/maven/buildcache/its/versioning/CiBuildDrivenProjectVersionChangeCachedTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/versioning/CiBuildDrivenProjectVersionChangeCachedTest.java
@@ -99,7 +99,7 @@ class CiBuildDrivenProjectVersionChangeCachedTest {
 
         // Build 2 — next CI build; revision bumped to 1.1; source code unchanged.
         // Version normalisation strips the version from the fingerprint → cache HIT.
-        Verifier verifier2 = new Verifier(verifier.getBasedir(), true);
+        Verifier verifier2 = new Verifier(verifier.getBasedir());
         verifier2.setAutoclean(false);
         verifier2.setLogFileName("../log-2.txt");
         verifier2.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
@@ -113,7 +113,7 @@ class CiBuildDrivenProjectVersionChangeCachedTest {
 
         // Build 3 — major version bump, release (no SNAPSHOT suffix); still no source change.
         // SNAPSHOT vs. release distinction is irrelevant to normalisation → cache HIT.
-        Verifier verifier3 = new Verifier(verifier.getBasedir(), true);
+        Verifier verifier3 = new Verifier(verifier.getBasedir());
         verifier3.setAutoclean(false);
         verifier3.setLogFileName("../log-3.txt");
         verifier3.setSystemProperty("projectVersion", System.getProperty("projectVersion"));

--- a/src/test/java/org/apache/maven/buildcache/its/versioning/RemoteParentVersionBumpInvalidatesTest.java
+++ b/src/test/java/org/apache/maven/buildcache/its/versioning/RemoteParentVersionBumpInvalidatesTest.java
@@ -72,7 +72,7 @@ class RemoteParentVersionBumpInvalidatesTest {
         String corpParentDir = Paths.get(verifier.getBasedir(), "_corp-parent")
                 .toAbsolutePath()
                 .toString();
-        Verifier corpInstallV1 = new Verifier(corpParentDir, true);
+        Verifier corpInstallV1 = new Verifier(corpParentDir);
         corpInstallV1.setAutoclean(false);
         corpInstallV1.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
         corpInstallV1.setLocalRepo(System.getProperty("localRepo"));
@@ -97,7 +97,7 @@ class RemoteParentVersionBumpInvalidatesTest {
         CacheITUtils.replaceInFile(corpParentPom, "<version>4.13.2</version>", "<version>4.12</version>");
 
         // Install corp-parent 1.1 into the test local repository.
-        Verifier corpInstallV11 = new Verifier(corpParentDir, true);
+        Verifier corpInstallV11 = new Verifier(corpParentDir);
         corpInstallV11.setAutoclean(false);
         corpInstallV11.setSystemProperty("projectVersion", System.getProperty("projectVersion"));
         corpInstallV11.setLocalRepo(System.getProperty("localRepo"));

--- a/src/test/projects/mbuildcache-115/pom.xml
+++ b/src/test/projects/mbuildcache-115/pom.xml
@@ -34,7 +34,8 @@
             <plugin>
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>2.7.0</version>
+                <!-- minimum Maven 4 compatible version; original was not compatible -->
+                <version>2.10.6</version>
 
                 <configuration>
                     <protocVersion>3.24.0</protocVersion>

--- a/src/test/projects/reference-test-projects/p10-reactor-partial/.mvn/maven-build-cache-config.xml
+++ b/src/test/projects/reference-test-projects/p10-reactor-partial/.mvn/maven-build-cache-config.xml
@@ -24,5 +24,6 @@ under the License.
     <configuration>
         <enabled>true</enabled>
         <hashAlgorithm>XX</hashAlgorithm>
+        <projectVersioning calculateProjectVersionChecksum="true"/>
     </configuration>
 </cache>

--- a/src/test/projects/remote-cache-dav/.mvn/maven.config
+++ b/src/test/projects/remote-cache-dav/.mvn/maven.config
@@ -1,0 +1,3 @@
+# Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
+-D
+aether.transport.http.supportWebDav=true

--- a/src/test/projects/remote-cache-dav/.mvn/maven.config
+++ b/src/test/projects/remote-cache-dav/.mvn/maven.config
@@ -1,3 +1,6 @@
-# Resolver 2 apache transport must have it explicitly enabled; is ignored by Resolver 1
+# Maven 3.10+: explicitly enable DAV
 -D
-aether.transport.http.supportWebDav=true
+aether.transport.http.supportWebDav
+# Maven 3.9: explicitly enable DAV
+-D
+aether.connector.http.supportWebDav


### PR DESCRIPTION
Reverse Maven versions (build against stable, test with stable + others), and fix the ITs as they never run against wanted Maven version. Also, let's do first Resolver 1 vs Resolver 2 (as in Maven 3.9.x vs Maven 3.10.x), as currently available Maven 4-rc-5 has so many changes happened since (ie JDK transport), that we should wait for 4-rc-6. And this PR solves the Resolver 2 anyway.

Fixed several issues:
* added GH actions to cover Maven 3.9, 3.10. Maven 4 still has inherent issues and cannot made to work with BCE, so dropping it for now. Focus on Resolver 2 first, and we will deal with Maven 4 later.
* no need for "outer" Maven matrix, we do it inside (w/ profile), the build itself can run with single (stable) maven version, everything else is just wasteful
* added Resolver 1 vs Resolver 2 changes (properties, exception handling)
* Verifier 1.8.0 quirk: uses `--debug` for "verbose output" that is repurposed in Maven 4 for "remote debugging", causing Maven 4 to stall and wait for remote debugger attach.
* Fixed Issue #511 as it was wrongly passing
* and finally, the extension is not tested on Java 8 (nor was), as build is Java 11+ and this is the problem of single module builds that IMO should never be done. Solution: refactor build into multiple modules, see https://maveniverse.eu/blog/2024/09/07/very-simple-ci-setup/

Contains fix for #511 
