### PR TITLE
Target Maven 4.0.0-rc-6 in the maven4.0 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@ under the License.
     <profile>
       <id>maven4.0</id>
       <properties>
-        <maven.version>4.0.0-rc-5</maven.version>
+        <maven.version>4.0.0-rc-6</maven.version>
         <maven.dir>maven4.0</maven.dir>
         <maven.basedir>${project.build.directory}/${maven.dir}</maven.basedir>
       </properties>


### PR DESCRIPTION
4.0.0-rc-6 is released, so the profile that provisions Maven 4 for the integration tests now points at the current RC. The README notes Maven 4 support was waiting on rc-6.

Verified on the fork: `Verify 4.x` and `Verify 3.10` both green. (`maven-verify-4.0.x.yml` reports as failed on every push in any fork or branch because its `on:` block is commented out — pre-existing, unrelated to this change.)
