### PR TITLE
Stop compiling against Wagon; classify not-found via the Resolver SPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,14 +217,11 @@ under the License.
       <version>${slf4jVersion}</version>
     </dependency>
 
+    <!-- Not compiled against: ships the "dav" Wagon provider so that a remote cache configured with a
+         dav: URL works. No Maven distribution bundles it, only wagon-file/wagon-http. -->
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-webdav-jackrabbit</artifactId>
-      <version>${wagonVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-provider-api</artifactId>
       <version>${wagonVersion}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@ under the License.
     </dependency>
 
     <!-- Not compiled against: ships the "dav" Wagon provider so that a remote cache configured with a
-         dav: URL works. No Maven distribution bundles it, only wagon-file/wagon-http. -->
+         dav: URL works. Maven distributions do not bundle the WebDAV wagon, so this dependency supplies it at runtime. -->
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-webdav-jackrabbit</artifactId>

--- a/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
+++ b/src/main/java/org/apache/maven/buildcache/RemoteCacheRepositoryImpl.java
@@ -25,8 +25,6 @@ import javax.inject.Named;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +43,6 @@ import org.apache.maven.buildcache.xml.report.CacheReport;
 import org.apache.maven.buildcache.xml.report.ProjectReport;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.Proxy;
@@ -154,13 +151,10 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
             GetTask task = new GetTask(new URI(url));
             transporter.get(task);
             return Optional.of(task.getDataBytes());
-        } catch (ResourceDoesNotExistException e) {
-            logNotFound(fullUrl, e);
-            return Optional.empty();
         } catch (Exception e) {
-            // this can be wagon used so the exception may be different
-            // we want wagon users not flooded with logs when not found
-            if (isHttpResponseException(e) && getStatusCode(e) == 404) {
+            // the transport in use (native HTTP, Wagon, ...) decides how a missing resource is signalled,
+            // so let it classify the failure instead of matching on transport specific exception types
+            if (isNotFound(e)) {
                 logNotFound(fullUrl, e);
                 return Optional.empty();
             }
@@ -174,39 +168,15 @@ public class RemoteCacheRepositoryImpl implements RemoteCacheRepository, Closeab
         }
     }
 
-    private boolean isHttpResponseException(Exception ex) {
-        Class<?> currentClass = ex.getClass();
-
-        while (currentClass != null) {
-            // Apache HttpClient 4.x
-            if ("org.apache.http.client.HttpResponseException".equals(currentClass.getName())) {
-                return true;
-            }
-            // Resolver 2 generic; used by all clients
-            if ("org.eclipse.aether.spi.connector.transport.http.HttpTransporterException"
-                    .equals(currentClass.getName())) {
-                return true;
-            }
-            currentClass = currentClass.getSuperclass();
-        }
-
-        return false;
-    }
-
-    private int getStatusCode(Exception exception) {
-        // just to avoid this when using wagon provide
-        // java.lang.ClassCastException: class org.apache.http.client.HttpResponseException cannot be cast to class
-        // org.apache.http.client.HttpResponseException
-        // (org.apache.http.client.HttpResponseException is in unnamed module of loader
-        // org.codehaus.plexus.classworlds.realm.ClassRealm @23cd4ff2;
-        //
-        try {
-            Method method = exception.getClass().getMethod("getStatusCode");
-            return (int) method.invoke(exception);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | RuntimeException ex) {
-            LOGGER.debug(ex.getMessage(), ex);
-            return 0;
-        }
+    /**
+     * Asks the transport whether the failure means "the resource is not there", so that a cache miss is not
+     * reported as an error. Every {@link Transporter} implementation knows its own not-found signal: the native
+     * HTTP transports map a 404/410 response, the Wagon transport maps
+     * {@code org.apache.maven.wagon.ResourceDoesNotExistException}. Delegating also avoids comparing exception
+     * types across class realms, which never matches when the transport is loaded by another realm.
+     */
+    private boolean isNotFound(Exception e) {
+        return transporter != null && transporter.classify(e) == Transporter.ERROR_NOT_FOUND;
     }
 
     private void logNotFound(String fullUrl, Exception e) {


### PR DESCRIPTION
`maven-build-cache-extension` compiled against Wagon for one thing: recognising "the remote cache does not have this item" so a miss stays quiet instead of logging an error.

```java
catch (ResourceDoesNotExistException e)   // RemoteCacheRepositoryImpl, around transporter.get()
```

Resolver's own SPI answers that question directly, and `maven-resolver-spi` is already a `provided` dependency:

```java
if (transporter.classify(e) == Transporter.ERROR_NOT_FOUND) { ... }
```

Every transporter that can be in play implements it — `WagonTransporter` returns `ERROR_NOT_FOUND` for exactly `ResourceDoesNotExistException`, and the HTTP transporters for 404 **and 410**.

Three things improve as a result:

- The reflective `getStatusCode()` call and the class-**name**-walking in `isHttpResponseException` both go. That hack existed to dodge a `ClassCastException` across class realms; `classify()` is the real fix, because the transport does the `instanceof` inside its own realm.
- `410 Gone` is now treated as a miss, which it previously was not.
- 47 lines out, 14 in.

`wagon-provider-api` is no longer declared.

### What is deliberately *not* changed

`wagon-webdav-jackrabbit` stays, and the POM now says why. It looks unused — nothing imports it — but it is what supplies the `dav:` transport at runtime:

- No Maven distribution ships it. `apache-maven-3.9.16/lib/` and the Maven 4 `lib/` carry `wagon-file`, `wagon-http`, `wagon-http-shared` and `wagon-provider-api` only. This POM is the sole source of the `dav` role hint on a user's machine.
- There is no fallback: Resolver's native HTTP transporter accepts `http`/`https` and throws `NoTransporterException` for anything else, and a `dav:http://…` URL has protocol `dav:http`.
- It is documented at `src/site/markdown/remote-cache.md:150-160` and exercised by `RemoteCacheDavTest` against a real WebDAV container.

Removing it would silently take `dav:` remote caches away from users. The comment is there so the next reader does not reach the "unused dependency" conclusion again.

### Verification

| | before | after |
|---|---|---|
| `mvn test` | 88 run, 0 failures, 0 errors, 4 skipped | 88 / 0 / 0 / 4 |
| `-Prun-its,run-its-smoke verify` | 121 / 0 / 0 / 0 | 121 / 0 / 0 / 0 |

`dependency:list` is byte-for-byte identical before and after — `wagon-provider-api` is still on the classpath, now transitively via the webdav wagon. This removes a declaration, not a jar.

**On whether those tests prove anything:** no unit test instantiates `RemoteCacheRepositoryImpl`, so the unit suite is not evidence here. The behaviour is covered by ITs that stub a 404 — `BaselineDiffTest` and `SaveFinalRemoteTest`. To confirm they genuinely guard it rather than merely passing, the not-found branch was mutated to `return false`: `BaselineDiffTest` then failed with `Error downloading cache item`. The mutation was reverted.

**One gap:** `RemoteCacheDavTest` self-skips without a Docker daemon, so the Wagon branch of `classify()` and the dav provider loading were not exercised locally. That test in CI is the check worth having before merge.
